### PR TITLE
Add Remove operation

### DIFF
--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -69,8 +69,7 @@ object Cop {
     def apply(a: A): Cop[L] = inj(a)
     def unapply(c: Cop[L]): Option[A] = proj(c)
 
-    type Rest = TList.Compute[TList.Op.Without[A, L]]#Out
-    def fold(c: Cop[L]): Either[Cop[Rest], A] =
+    def fold(c: Cop[L]): Either[Cop[TList.Op.Remove[A, L]], A] =
       Either.cond(
         c.index == index,
         c.value.asInstanceOf[A],

--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -68,12 +68,6 @@ object Cop {
       else None
     def apply(a: A): Cop[L] = inj(a)
     def unapply(c: Cop[L]): Option[A] = proj(c)
-
-    def fold(c: Cop[L]): Either[Cop[TList.Op.Remove[A, L]], A] =
-      Either.cond(
-        c.index == index,
-        c.value.asInstanceOf[A],
-        new Cop(if (c.index < index) c.index else c.index - 1, c.value))
   }
 
   object InjectL {
@@ -81,4 +75,19 @@ object Cop {
     implicit def makeInjectL[A, L <: TList](implicit ev: TList.Pos[L, A]): InjectL[A, L] =
       new InjectL[A, L](ev.index)
   }
+
+  final class RemoveL[A, L <: TList] private[RemoveL](index: Int) {
+    def apply(c: Cop[L]): Either[Cop[TList.Op.Remove[A, L]], A] =
+      Either.cond(
+        c.index == index,
+        c.value.asInstanceOf[A],
+        new Cop(if (c.index < index) c.index else c.index - 1, c.value))
+  }
+
+  object RemoveL {
+    def apply[A, L <: TList](implicit ev: RemoveL[A, L]): RemoveL[A, L] = ev
+    implicit def makeRemoveL[A, L <: TList](implicit ev: TList.Pos[L, A]): RemoveL[A, L] =
+      new RemoveL[A, L](ev.index)
+  }
+
 }

--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -68,6 +68,13 @@ object Cop {
       else None
     def apply(a: A): Cop[L] = inj(a)
     def unapply(c: Cop[L]): Option[A] = proj(c)
+
+    type Rest = TList.Compute[TList.Op.Without[A, L]]#Out
+    def fold(c: Cop[L]): Either[Cop[Rest], A] =
+      Either.cond(
+        c.index == index,
+        c.value.asInstanceOf[A],
+        new Cop(if (c.index < index) c.index else c.index - 1, c.value))
   }
 
   object InjectL {

--- a/modules/core/src/main/scala/iota/CopK.scala
+++ b/modules/core/src/main/scala/iota/CopK.scala
@@ -68,6 +68,12 @@ object CopK {
       else None
     def apply[A](fa: F[A]): CopK[L, A] = inj(fa)
     def unapply[A](ca: CopK[L, A]): Option[F[A]] = proj(ca)
+
+    def projEither[A](c: CopK[L, A]): Either[CopK[KList.Op.Remove[F, L], A], F[A]] =
+      Either.cond(
+        c.index == index,
+        c.value.asInstanceOf[F[A]],
+        new CopK(if (c.index < index) c.index else c.index - 1, c.value))
   }
 
   object InjectL {

--- a/modules/core/src/main/scala/iota/CopK.scala
+++ b/modules/core/src/main/scala/iota/CopK.scala
@@ -68,18 +68,26 @@ object CopK {
       else None
     def apply[A](fa: F[A]): CopK[L, A] = inj(fa)
     def unapply[A](ca: CopK[L, A]): Option[F[A]] = proj(ca)
-
-    def projEither[A](c: CopK[L, A]): Either[CopK[KList.Op.Remove[F, L], A], F[A]] =
-      Either.cond(
-        c.index == index,
-        c.value.asInstanceOf[F[A]],
-        new CopK(if (c.index < index) c.index else c.index - 1, c.value))
   }
 
   object InjectL {
     def apply[F[_], L <: KList](implicit ev: InjectL[F, L]): InjectL[F, L] = ev
     implicit def makeInjectL[F[_], L <: KList](implicit ev: KList.Pos[L, F]): InjectL[F, L] =
       new InjectL[F, L](ev.index)
+  }
+
+  final class RemoveL[F[_], L <: KList] private[RemoveL](index: Int) {
+    def apply[A](c: CopK[L, A]): Either[CopK[KList.Op.Remove[F, L], A], F[A]] =
+      Either.cond(
+        c.index == index,
+        c.value.asInstanceOf[F[A]],
+        new CopK(if (c.index < index) c.index else c.index - 1, c.value))
+  }
+
+  object RemoveL {
+    def apply[F[_], L <: KList](implicit ev: RemoveL[F, L]): RemoveL[F, L] = ev
+    implicit def makeRemoveL[F[_], L <: KList](implicit ev: KList.Pos[L, F]): RemoveL[F, L] =
+      new RemoveL[F, L](ev.index)
   }
 
   val FunctionK: CopKFunctionK.type = CopKFunctionK

--- a/modules/core/src/main/scala/iota/KList.scala
+++ b/modules/core/src/main/scala/iota/KList.scala
@@ -45,7 +45,7 @@ object KList {
     type Reverse[L <: KList]                    <: KList
     type Take   [N <: SingletonInt, L <: KList] <: KList
     type Drop   [N <: SingletonInt, L <: KList] <: KList
-    type Without[K[_], L <: KList]              <: KList
+    type Remove [K[_], L <: KList]              <: KList
   }
 
   trait Compute[L <: KList] {

--- a/modules/core/src/main/scala/iota/KList.scala
+++ b/modules/core/src/main/scala/iota/KList.scala
@@ -45,6 +45,7 @@ object KList {
     type Reverse[L <: KList]                    <: KList
     type Take   [N <: SingletonInt, L <: KList] <: KList
     type Drop   [N <: SingletonInt, L <: KList] <: KList
+    type Without[K[_], L <: KList]              <: KList
   }
 
   trait Compute[L <: KList] {

--- a/modules/core/src/main/scala/iota/TList.scala
+++ b/modules/core/src/main/scala/iota/TList.scala
@@ -45,7 +45,7 @@ object TList {
     type Reverse[L <: TList]                    <: TList
     type Take   [N <: SingletonInt, L <: TList] <: TList
     type Drop   [N <: SingletonInt, L <: TList] <: TList
-    type Without[T, L <: TList]                 <: TList
+    type Remove [T, L <: TList]                 <: TList
   }
 
   trait Compute[L <: TList] {

--- a/modules/core/src/main/scala/iota/TList.scala
+++ b/modules/core/src/main/scala/iota/TList.scala
@@ -45,6 +45,7 @@ object TList {
     type Reverse[L <: TList]                    <: TList
     type Take   [N <: SingletonInt, L <: TList] <: TList
     type Drop   [N <: SingletonInt, L <: TList] <: TList
+    type Without[T, L <: TList]                 <: TList
   }
 
   trait Compute[L <: TList] {

--- a/modules/core/src/main/scala/iota/internal/toolbelts.scala
+++ b/modules/core/src/main/scala/iota/internal/toolbelts.scala
@@ -98,35 +98,39 @@ private[internal] sealed trait TypeListTrees { self: Toolbelt =>
   case class   ReverseF[A](node: A)             extends NodeF[A]
   case class   TakeF   [A](n: Int, node: A)     extends NodeF[A]
   case class   DropF   [A](n: Int, node: A)     extends NodeF[A]
+  case class   WithoutF[A](t: Type, nodes: A)   extends NodeF[A]
   case object  NNilF                            extends NodeF[Nothing]
 
   object NodeF {
     implicit val nodeTraverse: Traverse[NodeF] = new Traverse[NodeF] {
       def traverse[G[_], A, B](fa: NodeF[A])(f: A => G[B])(implicit G: Applicative[G]): G[NodeF[B]] = fa match {
-        case ConsF(hd, a) => G.map(f(a))(ConsF(hd, _))
-        case ConcatF(as)  => G.map(Traverse[List].traverse(as)(f))(ConcatF(_))
-        case ReverseF(a)  => G.map(f(a))(ReverseF(_))
-        case TakeF(n, a)  => G.map(f(a))(TakeF(n, _))
-        case DropF(n, a)  => G.map(f(a))(DropF(n, _))
-        case NNilF        => G.pure(NNilF: NodeF[B])
+        case ConsF(hd, a)   => G.map(f(a))(ConsF(hd, _))
+        case ConcatF(as)    => G.map(Traverse[List].traverse(as)(f))(ConcatF(_))
+        case ReverseF(a)    => G.map(f(a))(ReverseF(_))
+        case TakeF(n, a)    => G.map(f(a))(TakeF(n, _))
+        case DropF(n, a)    => G.map(f(a))(DropF(n, _))
+        case WithoutF(t, a) => G.map(f(a))(WithoutF(t, _))
+        case NNilF          => G.pure(NNilF: NodeF[B])
       }
 
       def foldLeft[A, B](fa: NodeF[A], b: B)(f: (B, A) => B): B = fa match {
-        case ConsF(_, a)  => f(b, a)
-        case ConcatF(as)  => Foldable[List].foldLeft(as, b)(f)
-        case ReverseF(a)  => f(b, a)
-        case TakeF(_, a)  => f(b, a)
-        case DropF(_, a)  => f(b, a)
-        case NNilF        => b
+        case ConsF(_, a)    => f(b, a)
+        case ConcatF(as)    => Foldable[List].foldLeft(as, b)(f)
+        case ReverseF(a)    => f(b, a)
+        case TakeF(_, a)    => f(b, a)
+        case DropF(_, a)    => f(b, a)
+        case WithoutF(_, a) => f(b, a)
+        case NNilF          => b
       }
 
       def foldRight[A, B](fa: NodeF[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = fa match {
-        case ConsF(_, a)  => f(a, lb)
-        case ConcatF(as)  => Foldable[List].foldRight(as, lb)(f)
-        case ReverseF(a)  => f(a, lb)
-        case TakeF(_, a)  => f(a, lb)
-        case DropF(_, a)  => f(a, lb)
-        case NNilF        => lb
+        case ConsF(_, a)    => f(a, lb)
+        case ConcatF(as)    => Foldable[List].foldRight(as, lb)(f)
+        case ReverseF(a)    => f(a, lb)
+        case TakeF(_, a)    => f(a, lb)
+        case DropF(_, a)    => f(a, lb)
+        case WithoutF(_, a) => f(a, lb)
+        case NNilF          => lb
       }
     }
   }
@@ -149,7 +153,8 @@ private[internal] sealed trait TypeListParsers { self: Toolbelt with TypeListTre
     ConcatSym : Symbol,
     ReverseSym: Symbol,
     TakeSym   : Symbol,
-    DropSym   : Symbol
+    DropSym   : Symbol,
+    WithoutSym: Symbol
   ): Parser = tpe0 => {
     @tailrec def loop(tpe: Type): Either[Id[String], NodeF[Type]] = tpe.dealias match {
       case TypeRef(_, sym, args) =>
@@ -160,6 +165,7 @@ private[internal] sealed trait TypeListParsers { self: Toolbelt with TypeListTre
           case ReverseSym => ReverseF(args(0)).asRight
           case TakeSym    => literalInt(args(0)).map(TakeF(_, args(1)))
           case DropSym    => literalInt(args(0)).map(DropF(_, args(1)))
+          case WithoutSym => WithoutF(args(0), args(1)).asRight
           case sym        => s"Unexpected symbol $sym for type $tpe".asLeft
         }
       case ExistentialType(_, res) => loop(res) // the irony...
@@ -176,7 +182,8 @@ private[internal] sealed trait TypeListParsers { self: Toolbelt with TypeListTre
     ConcatSym  = symbolOf[iota.TList.Op.Concat[Nothing, Nothing]],
     ReverseSym = symbolOf[iota.TList.Op.Reverse[Nothing]],
     TakeSym    = symbolOf[iota.TList.Op.Take[Nothing, Nothing]],
-    DropSym    = symbolOf[iota.TList.Op.Drop[Nothing, Nothing]])
+    DropSym    = symbolOf[iota.TList.Op.Drop[Nothing, Nothing]],
+    WithoutSym = symbolOf[iota.TList.Op.Without[Nothing, Nothing]])
 
   final lazy val klistParser: Parser = typeListParser(
     NilSym     = symbolOf[iota.KNil],
@@ -184,7 +191,8 @@ private[internal] sealed trait TypeListParsers { self: Toolbelt with TypeListTre
     ConcatSym  = symbolOf[iota.KList.Op.Concat[Nothing, Nothing]],
     ReverseSym = symbolOf[iota.KList.Op.Reverse[Nothing]],
     TakeSym    = symbolOf[iota.KList.Op.Take[Nothing, Nothing]],
-    DropSym    = symbolOf[iota.KList.Op.Drop[Nothing, Nothing]])
+    DropSym    = symbolOf[iota.KList.Op.Drop[Nothing, Nothing]],
+    WithoutSym = symbolOf[iota.KList.Op.Without[Nothing, Nothing]])
 }
 
 private[internal] sealed trait TypeListEvaluators { self: Toolbelt with TypeListTrees with TypeListParsers =>
@@ -196,6 +204,7 @@ private[internal] sealed trait TypeListEvaluators { self: Toolbelt with TypeList
     case ReverseF(types)    => types.reverse
     case TakeF(n, types)    => types.take(n)
     case DropF(n, types)    => types.drop(n)
+    case WithoutF(t, types) => types.filterNot(_ =:= t)
     case NNilF              => Nil
   }
 

--- a/modules/core/src/test/scala/iota/internal/TestTreeHelper.scala
+++ b/modules/core/src/test/scala/iota/internal/TestTreeHelper.scala
@@ -38,10 +38,10 @@ class TestTreeHelper(val tb: Toolbelt with TypeListTrees) {
   def reverse(node: Fix[NodeF])     : Fix[NodeF] = Fix[NodeF](ReverseF(node))
   def take(n: Int, node: Fix[NodeF]): Fix[NodeF] = Fix[NodeF](TakeF(n, node))
   def drop(n: Int, node: Fix[NodeF]): Fix[NodeF] = Fix[NodeF](DropF(n, node))
-  def without[T](node: Fix[NodeF] = nnil)(
-    implicit evT: WeakTypeTag[T])   : Fix[NodeF] = Fix[NodeF](WithoutF(evT.tpe, node))
-  def withoutk[T[_]](node: Fix[NodeF] = nnil)(
-    implicit evT: WeakTypeTag[T[_]]): Fix[NodeF] = Fix[NodeF](WithoutF(evT.tpe.typeConstructor, node))
+  def remove[T](node: Fix[NodeF] = nnil)(
+    implicit evT: WeakTypeTag[T])   : Fix[NodeF] = Fix[NodeF](RemoveF(evT.tpe, node))
+  def removek[T[_]](node: Fix[NodeF] = nnil)(
+    implicit evT: WeakTypeTag[T[_]]): Fix[NodeF] = Fix[NodeF](RemoveF(evT.tpe.typeConstructor, node))
 }
 
 //#-jvm

--- a/modules/core/src/test/scala/iota/internal/TestTreeHelper.scala
+++ b/modules/core/src/test/scala/iota/internal/TestTreeHelper.scala
@@ -38,7 +38,10 @@ class TestTreeHelper(val tb: Toolbelt with TypeListTrees) {
   def reverse(node: Fix[NodeF])     : Fix[NodeF] = Fix[NodeF](ReverseF(node))
   def take(n: Int, node: Fix[NodeF]): Fix[NodeF] = Fix[NodeF](TakeF(n, node))
   def drop(n: Int, node: Fix[NodeF]): Fix[NodeF] = Fix[NodeF](DropF(n, node))
-
+  def without[T](node: Fix[NodeF] = nnil)(
+    implicit evT: WeakTypeTag[T])   : Fix[NodeF] = Fix[NodeF](WithoutF(evT.tpe, node))
+  def withoutk[T[_]](node: Fix[NodeF] = nnil)(
+    implicit evT: WeakTypeTag[T[_]]): Fix[NodeF] = Fix[NodeF](WithoutF(evT.tpe.typeConstructor, node))
 }
 
 //#-jvm

--- a/modules/core/src/test/scala/iota/internal/TypeListEvaluationChecks.scala
+++ b/modules/core/src/test/scala/iota/internal/TypeListEvaluationChecks.scala
@@ -89,9 +89,10 @@ class TypeListEvaluationChecks(
     drop(2, cons[String](cons[Double]())) -> (Nil),
     drop(3, cons[String](cons[Double]())) -> (Nil),
 
-    without[Double](cons[Double](cons[String](cons[Int]()))) -> (t[String] :: t[Int] :: Nil),
-    without[String](cons[Double](cons[String](cons[Int]()))) -> (t[Double] :: t[Int] :: Nil),
-    without[Int   ](cons[Double](cons[String](cons[Int]()))) -> (t[Double] :: t[String] :: Nil)
+    remove[Double](cons[Double](cons[String](cons[Int]()))) -> (t[String] :: t[Int] :: Nil),
+    remove[String](cons[Double](cons[String](cons[Int]()))) -> (t[Double] :: t[Int] :: Nil),
+    remove[Int   ](cons[Double](cons[String](cons[Int]()))) -> (t[Double] :: t[String] :: Nil),
+    remove[String](cons[String](cons[String](cons[Int]()))) -> (t[String] :: t[Int] :: Nil)
 
   )
 

--- a/modules/core/src/test/scala/iota/internal/TypeListEvaluationChecks.scala
+++ b/modules/core/src/test/scala/iota/internal/TypeListEvaluationChecks.scala
@@ -87,7 +87,12 @@ class TypeListEvaluationChecks(
     drop(0, cons[String](cons[Double]())) -> (t[String] :: t[Double] :: Nil),
     drop(1, cons[String](cons[Double]())) -> (t[Double] :: Nil),
     drop(2, cons[String](cons[Double]())) -> (Nil),
-    drop(3, cons[String](cons[Double]())) -> (Nil)
+    drop(3, cons[String](cons[Double]())) -> (Nil),
+
+    without[Double](cons[Double](cons[String](cons[Int]()))) -> (t[String] :: t[Int] :: Nil),
+    without[String](cons[Double](cons[String](cons[Int]()))) -> (t[Double] :: t[Int] :: Nil),
+    without[Int   ](cons[Double](cons[String](cons[Int]()))) -> (t[Double] :: t[String] :: Nil)
+
   )
 
 }

--- a/modules/core/src/test/scala/iota/internal/TypeListParserChecks.scala
+++ b/modules/core/src/test/scala/iota/internal/TypeListParserChecks.scala
@@ -53,7 +53,7 @@ class TypeListParserChecks(
     Reverse => TReverse,
     Take    => TTake,
     Drop    => TDrop,
-    Without => TWithout
+    Remove => TRemove
   }
 
   val tlists: List[(Type, Node)] = List(
@@ -76,8 +76,8 @@ class TypeListParserChecks(
     t[TDrop[2, BazBarFoo#L]] -> drop(2, cons[Baz](cons[Bar](cons[Foo]()))),
     t[TDrop[3, BazBarFoo#L]] -> drop(3, cons[Baz](cons[Bar](cons[Foo]()))),
 
-    t[TWithout[Baz, BazBarFoo#L]] -> without[Baz](cons[Baz](cons[Bar](cons[Foo]()))),
-    t[TWithout[Foo, BazBarFoo#L]] -> without[Foo](cons[Baz](cons[Bar](cons[Foo]())))
+    t[TRemove[Baz, BazBarFoo#L]] -> remove[Baz](cons[Baz](cons[Bar](cons[Foo]()))),
+    t[TRemove[Foo, BazBarFoo#L]] -> remove[Foo](cons[Baz](cons[Bar](cons[Foo]())))
   )
 
   import KList.Op.{
@@ -85,7 +85,7 @@ class TypeListParserChecks(
     Reverse => KReverse,
     Take    => KTake,
     Drop    => KDrop,
-    Without => KWithout
+    Remove => KRemove
   }
 
   val klists: List[(Type, Node)] = List(
@@ -105,8 +105,8 @@ class TypeListParserChecks(
     t[KDrop[2, BazBarFooK[_]#L]] -> drop(2, consk[BazK](consk[BarK](consk[FooK]()))),
     t[KDrop[3, BazBarFooK[_]#L]] -> drop(3, consk[BazK](consk[BarK](consk[FooK]()))),
 
-    t[KWithout[BazK, BazBarFooK[_]#L]] -> withoutk[BazK](consk[BazK](consk[BarK](consk[FooK]()))),
-    t[KWithout[FooK, BazBarFooK[_]#L]] -> withoutk[FooK](consk[BazK](consk[BarK](consk[FooK]())))
+    t[KRemove[BazK, BazBarFooK[_]#L]] -> removek[BazK](consk[BazK](consk[BarK](consk[FooK]()))),
+    t[KRemove[FooK, BazBarFooK[_]#L]] -> removek[FooK](consk[BazK](consk[BarK](consk[FooK]())))
   )
 
 }

--- a/modules/core/src/test/scala/iota/internal/TypeListParserChecks.scala
+++ b/modules/core/src/test/scala/iota/internal/TypeListParserChecks.scala
@@ -52,7 +52,8 @@ class TypeListParserChecks(
     Concat  => TConcat,
     Reverse => TReverse,
     Take    => TTake,
-    Drop    => TDrop
+    Drop    => TDrop,
+    Without => TWithout
   }
 
   val tlists: List[(Type, Node)] = List(
@@ -73,14 +74,18 @@ class TypeListParserChecks(
     t[TTake[1, BazBarFoo#L]] -> take(1, cons[Baz](cons[Bar](cons[Foo]()))),
 
     t[TDrop[2, BazBarFoo#L]] -> drop(2, cons[Baz](cons[Bar](cons[Foo]()))),
-    t[TDrop[3, BazBarFoo#L]] -> drop(3, cons[Baz](cons[Bar](cons[Foo]())))
+    t[TDrop[3, BazBarFoo#L]] -> drop(3, cons[Baz](cons[Bar](cons[Foo]()))),
+
+    t[TWithout[Baz, BazBarFoo#L]] -> without[Baz](cons[Baz](cons[Bar](cons[Foo]()))),
+    t[TWithout[Foo, BazBarFoo#L]] -> without[Foo](cons[Baz](cons[Bar](cons[Foo]())))
   )
 
   import KList.Op.{
     Concat  => KConcat,
     Reverse => KReverse,
     Take    => KTake,
-    Drop    => KDrop
+    Drop    => KDrop,
+    Without => KWithout
   }
 
   val klists: List[(Type, Node)] = List(
@@ -98,7 +103,10 @@ class TypeListParserChecks(
     t[KTake[1, BazBarFooK[_]#L]] -> take(1, consk[BazK](consk[BarK](consk[FooK]()))),
 
     t[KDrop[2, BazBarFooK[_]#L]] -> drop(2, consk[BazK](consk[BarK](consk[FooK]()))),
-    t[KDrop[3, BazBarFooK[_]#L]] -> drop(3, consk[BazK](consk[BarK](consk[FooK]())))
+    t[KDrop[3, BazBarFooK[_]#L]] -> drop(3, consk[BazK](consk[BarK](consk[FooK]()))),
+
+    t[KWithout[BazK, BazBarFooK[_]#L]] -> withoutk[BazK](consk[BazK](consk[BarK](consk[FooK]()))),
+    t[KWithout[FooK, BazBarFooK[_]#L]] -> withoutk[FooK](consk[BazK](consk[BarK](consk[FooK]())))
   )
 
 }

--- a/modules/core/src/test/scala/iotatests/KListChecks.scala
+++ b/modules/core/src/test/scala/iotatests/KListChecks.scala
@@ -56,7 +56,8 @@ object KListChecks {
 
   check[Drop[1, OptionListL], List :: KNil]
 
-  check[Without[Option, OptionListL], List :: KNil]
-  check[Without[List, OptionListL], Option :: KNil]
+  check[Remove[Option, OptionListL], List :: KNil]
+  check[Remove[List, OptionListL], Option :: KNil]
+  check[Remove[List, List :: List :: KNil], List :: KNil]
 
 }

--- a/modules/core/src/test/scala/iotatests/KListChecks.scala
+++ b/modules/core/src/test/scala/iotatests/KListChecks.scala
@@ -56,4 +56,7 @@ object KListChecks {
 
   check[Drop[1, OptionListL], List :: KNil]
 
+  check[Without[Option, OptionListL], List :: KNil]
+  check[Without[List, OptionListL], Option :: KNil]
+
 }

--- a/modules/core/src/test/scala/iotatests/TListChecks.scala
+++ b/modules/core/src/test/scala/iotatests/TListChecks.scala
@@ -48,7 +48,8 @@ object TListChecks {
   check[Concat[StringInt#L, IntString#L],
     String :: Int :: Int :: String :: TNil]
 
-  check[Without[String, StringIntL], Int :: TNil]
-  check[Without[Int, StringIntL], String :: TNil]
+  check[Remove[String, StringIntL], Int :: TNil]
+  check[Remove[Int, StringIntL], String :: TNil]
+  check[Remove[Int, Int :: Int :: TNil], Int :: TNil]
 
 }

--- a/modules/core/src/test/scala/iotatests/TListChecks.scala
+++ b/modules/core/src/test/scala/iotatests/TListChecks.scala
@@ -48,4 +48,7 @@ object TListChecks {
   check[Concat[StringInt#L, IntString#L],
     String :: Int :: Int :: String :: TNil]
 
+  check[Without[String, StringIntL], Int :: TNil]
+  check[Without[Int, StringIntL], String :: TNil]
+
 }


### PR DESCRIPTION
The ability to create a new coproduct by removing a type from an existing coproduct.

Not really convinced about `Without`, any suggestions for a better name?

I don't know if we check somewhere that the types in the coproduct are unique?
The `Pos` instances point to the first index, so I don't think it would make sense to have one type more than once.
If the types are unique, I could probably replace `filter` with something that doesn't iterate over the whole list.