### PR TITLE
Fix typo in the source for the README.me file

### DIFF
--- a/modules/readme/src/main/tut/README.md
+++ b/modules/readme/src/main/tut/README.md
@@ -168,7 +168,7 @@ val evalAlgebra2: Algebra ~> Future = CopK.FunctionK.summon
 ```
 
 The interpreters created by Iota are optimized for speed and have a
-constant evalaluation time. Behind the scenes, a macro generates an
+constant evaluation time. Behind the scenes, a macro generates an
 integer based switch statement on the coproduct's internal index value.
 
 If you'd like to see the generated code, toggle the "show trees" option by


### PR DESCRIPTION
Addresses https://github.com/frees-io/iota/pull/55 so that the fix will be included whenever the CI bot publishes a new build.