### PR TITLE
Bump cats to 1.0.0-MF; adjust Injects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ import cats.data._
 // a coproduct of types using scala.util.Either
 type EitherFoo = Either[Int, Either[String, Double]]
 
-// a coproduct of type constructors using cats.data.Coproduct
-type CoproductBar0[A] = Coproduct[List, Seq, A]
-type CoproductBar[A] = Coproduct[Option, CoproductBar0, A]
+// a coproduct of type constructors using cats.data.EitherK
+type EitherKBar0[A] = EitherK[List, Seq, A]
+type EitherKBar[A] = EitherK[Option, EitherKBar0, A]
 ```
 
 Iota coproducts are linked lists at the type level. At the value level,

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ lazy val core = module("core", hideFolder = true)
   .settings(yax(file("modules/core/src/test/scala"), Test,
     yaxPlatform = true))
   .crossDepSettings(
-    %%("cats-core"),
-    %%("cats-free"),
+    %%("cats-core", V.cats),
+    %%("cats-free", V.cats),
     %%("scalacheck")      % "test",
     %%("shapeless")       % "test",
     %%("scheckShapeless") % "test")
@@ -43,7 +43,6 @@ lazy val bench = jvmModule("bench")
   .settings(classpathConfiguration in Codegen := Compile)
   .settings(noPublishSettings)
   .settings(libraryDependencies ++= Seq(
-    %%("cats-free"),
     %%("scalacheck")))
   .settings(inConfig(Compile)(
     sourceGenerators += Def.task {
@@ -62,3 +61,7 @@ lazy val Codegen = config("codegen").hide
 pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.asc")
 pgpSecretRing := file(s"$gpgFolder/secring.asc")
+
+lazy val V = new {
+  val cats = "1.0.0-MF"
+}

--- a/modules/bench/src/codegen/scala/codegen.scala
+++ b/modules/bench/src/codegen/scala/codegen.scala
@@ -59,7 +59,6 @@ object BenchBoiler {
       |import iota._
       |import cats._
       |import cats.data.{ State => _, _ }
-      |import cats.free._
       |
       |import org.scalacheck._
       |
@@ -83,7 +82,7 @@ object BenchBoiler {
         ${catsEvals.mkString("\n")}
       |
       |  private[this] implicit class InjectGenOps[F[_]](gf: Gen[F[_]]) {
-      |    def inj[G[_]](implicit ev: Inject[F, G]): Gen[G[_]] = gf.map(f => ev.inj(f))
+      |    def inj[G[_]](implicit ev: InjectK[F, G]): Gen[G[_]] = gf.map(f => ev.inj(f))
       |  }
       |
         ${genAlgebras.mkString("\n")}
@@ -151,7 +150,7 @@ object BenchBoiler {
     prevName: String,
     name: String
   ): String =
-    s"|  type Algebra$name[A] = Coproduct[${name}Op, Algebra$prevName, A]"
+    s"|  type Algebra$name[A] = EitherK[${name}Op, Algebra$prevName, A]"
 
   def catsEvalHeadTemplate(
     name: String

--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -40,12 +40,7 @@ object Cop {
   /** A type class witnessing the ability to inject type `A` into a
     * coproduct of types `B`
     */
-  sealed abstract class Inject[A, B <: Cop[_]] {
-    def inj(a: A): B
-    def proj(b: B): Option[A]
-    final def apply(a: A): B = inj(a)
-    final def unapply(b: B): Option[A] = proj(b)
-  }
+  sealed abstract class Inject[A, B <: Cop[_]] extends cats.Inject[A, B]
 
   object Inject {
     def apply[A, B <: Cop[_]](implicit ev: Inject[A, B]): Inject[A, B] = ev
@@ -53,8 +48,8 @@ object Cop {
     implicit def injectFromInjectL[A, L <: TList](
       implicit ev: InjectL[A, L]
     ): Inject[A, Cop[L]] = new Inject[A, Cop[L]] {
-      def inj(a: A): Cop[L] = ev.inj(a)
-      def proj(c: Cop[L]): Option[A] = ev.proj(c)
+      val inj: A => Cop[L] = ev.inj(_)
+      val prj: Cop[L] => Option[A] = ev.proj(_)
     }
   }
 

--- a/modules/readme/src/main/tut/README.md
+++ b/modules/readme/src/main/tut/README.md
@@ -22,9 +22,9 @@ import cats.data._
 // a coproduct of types using scala.util.Either
 type EitherFoo = Either[Int, Either[String, Double]]
 
-// a coproduct of type constructors using cats.data.Coproduct
-type CoproductBar0[A] = Coproduct[List, Seq, A]
-type CoproductBar[A] = Coproduct[Option, CoproductBar0, A]
+// a coproduct of type constructors using cats.data.EitherK
+type EitherKBar0[A] = EitherK[List, Seq, A]
+type EitherKBar[A] = EitherK[Option, EitherKBar0, A]
 ```
 
 Iota coproducts are linked lists at the type level. At the value level,


### PR DESCRIPTION
This is the minimum amount of work to bump to cats 1.0.0 and provide compatibility with `cats.Inject` and `cats.InjectK`.

New tests should be added to verify that the cats syntax can be used for injections. The packaging/implicits may need to be adjusted to support this.