### PR TITLE
Ensure Idents are qualified/attributed when creating FastFunctionKs

### DIFF
--- a/modules/core/src/test/scala/iotatests/FreeCopKTests.scala
+++ b/modules/core/src/test/scala/iotatests/FreeCopKTests.scala
@@ -87,10 +87,10 @@ object FreeCopK extends Properties("FreeCopK") {
     type Op[A] = CopK[OpTypes, A]
   }
 
-  // not found: type Op
+  // must compile
   val evalSummonModule = CopK.FunctionK.summon[Module.Op, Id]
 
-  // not found: type Op
+  // must compile
   val evalOfModule     = CopK.FunctionK.of[Module.Op, Id](
     evalAddOne, evalXTwo, evalHalf, evalNeg)
 }

--- a/modules/core/src/test/scala/iotatests/FreeCopKTests.scala
+++ b/modules/core/src/test/scala/iotatests/FreeCopKTests.scala
@@ -82,4 +82,15 @@ object FreeCopK extends Properties("FreeCopK") {
   property("basic math program regular interpreter") =
     program.foldMap(evalOf) ?= -303
 
+  object Module {
+    type OpTypes = AddOne :: XTwo :: Neg :: Half :: TNilK
+    type Op[A] = CopK[OpTypes, A]
+  }
+
+  // not found: type Op
+  val evalSummonModule = CopK.FunctionK.summon[Module.Op, Id]
+
+  // not found: type Op
+  val evalOfModule     = CopK.FunctionK.of[Module.Op, Id](
+    evalAddOne, evalXTwo, evalHalf, evalNeg)
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -75,7 +75,7 @@ object ProjectPlugin extends AutoPlugin {
     connectInput in run := true,
     cancelable in Global := true,
 
-    scalaOrganization := "org.typelevel",    
+    scalaOrganization := "org.typelevel",
     crossScalaVersions:=  List("2.11.8", "2.12.1"),
     scalaVersion      := "2.12.1",
 
@@ -85,6 +85,11 @@ object ProjectPlugin extends AutoPlugin {
       "-Yno-predef",
       "-Ypartial-unification",
       "-Yliteral-types"),
+
+    scalacOptions := (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => scalacOptions.value
+      case _             => scalacOptions.value.filter(_ != "-Xfatal-warnings")
+    }),
 
     scalacOptions in (Compile, doc) :=
       (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings")


### PR DESCRIPTION
This addresses a recently discovered issue that affects the Freestyle core libraries.