### PR TITLE
Use NEL.one instead of NEL.of

### DIFF
--- a/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
@@ -40,8 +40,8 @@ final class CopKFunctionKMacros(val c: Context) {
     val G = evG.tpe
 
     tb.foldAbort(for {
-      copK <- tb.destructCopK(F).leftMap(NonEmptyList.of(_))
-      tpes <- tb.memoizedTListKTypes(copK.L).leftMap(NonEmptyList.of(_))
+      copK <- tb.destructCopK(F).leftMap(NonEmptyList.one(_))
+      tpes <- tb.memoizedTListKTypes(copK.L).leftMap(NonEmptyList.one(_))
 
       unorderedPairs <- Traverse[List].traverse(args.toList)(arg =>
         destructFunctionKInput(arg.tree.tpe, G).map((_, arg.tree))).toEither
@@ -62,8 +62,8 @@ final class CopKFunctionKMacros(val c: Context) {
     val G = evG.tpe
 
     tb.foldAbort(for {
-      copK <- tb.destructCopK(F).leftMap(NonEmptyList.of(_))
-      tpes <- tb.memoizedTListKTypes(copK.L).leftMap(NonEmptyList.of(_))
+      copK <- tb.destructCopK(F).leftMap(NonEmptyList.one(_))
+      tpes <- tb.memoizedTListKTypes(copK.L).leftMap(NonEmptyList.one(_))
 
       arrs <- Traverse[List].traverse(tpes)(tpe =>
                 summonFunctionK(tpe, G)).toEither
@@ -98,7 +98,7 @@ final class CopKFunctionKMacros(val c: Context) {
     Validated
       .catchOnly[TypecheckException](
         c.typecheck(q"_root_.scala.Predef.implicitly[_root_.cats.arrow.FunctionK[$F, $G]]"))
-      .leftMap(t => NonEmptyList.of(t.msg))
+      .leftMap(t => NonEmptyList.one(t.msg))
 
   private[this] def destructFunctionKInput(tpe: Type, G: Type): ValidatedNel[String, Type] =
     tpe match {

--- a/modules/core/src/main/scala/iota/internal/ProductMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/ProductMacros.scala
@@ -37,7 +37,7 @@ private[iota] final class ProductMacros(val c: Context) {
     val L = evL.tpe
 
     tb.foldAbort(for {
-      algebras <- tb.memoizedTListTypes(L).leftMap(NonEmptyList.of(_))
+      algebras <- tb.memoizedTListTypes(L).leftMap(NonEmptyList.one(_))
       argTypes  = args.toList.map(_.tree.tpe)
       _        <- require(argTypes.length == algebras.length,
                     s"Expected ${algebras.length} arguments but received ${argTypes.length}")
@@ -49,6 +49,6 @@ private[iota] final class ProductMacros(val c: Context) {
   }
 
   private[this] def require(flag: Boolean, msg: => String): Either[NonEmptyList[String], Unit] =
-    Either.cond(flag, (), msg).leftMap(NonEmptyList.of(_))
+    Either.cond(flag, (), msg).leftMap(NonEmptyList.one(_))
 
 }


### PR DESCRIPTION
`NonEmptyList.one` is a bit faster. See https://github.com/typelevel/cats/pull/1707.