### PR TITLE
Split README / Fix Scalaz

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ type EitherFoo = Either[Int, Either[String, Double]]
 // a coproduct of type constructors using cats.data.EitherK
 import cats.data.EitherK
 type EitherKBar0[A] = EitherK[List, Seq, A]
-type EitherKBar[A] = EitherK[Option, EitherKBar0, A]
+type EitherKBar[A]  = EitherK[Option, EitherKBar0, A]
 
 // a coproduct of type constructors using scalaz.Coproduct
 import scalaz.Coproduct
 type CoproductKBar0[A] = Coproduct[List, Seq, A]
-type CoproductKBar[A] = Coproduct[Option, CoproductKBar0, A]
+type CoproductKBar[A]  = Coproduct[Option, CoproductKBar0, A]
 ```
 
 Iota coproducts are linked lists at the type level. At the value level,
@@ -38,7 +38,21 @@ constant time access of the values. This syntax scales cleanly to
 support any number of disjunct types.
 
 ```scala
-import iota._ // or iotaz._
+// for cats
+import iota._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+```scala
+// for scalaz
+import iotaz._
 import TList.::
 import TListK.:::
 
@@ -85,155 +99,9 @@ The Cats examples will work against Scalaz, and vise versa, so long as the
 library specific terminology is adjusted. Expect more Scalaz examples as the
 Iota library evolves.
 
-## Injection type classes
-
-Iota provides injection type classes to make it easy to get values in
-and out of your coproducts.
-
-*coproduct of types*
-
-```scala
-val IntFoo    = Cop.Inject[Int,    Foo]
-val StringFoo = Cop.Inject[String, Foo]
-val DoubleFoo = Cop.Inject[Double, Foo]
-
-def processFoo(foo: Foo): String = foo match {
-  case IntFoo(int)       => s"int: $int"
-  case StringFoo(string) => s"string: $string"
-  case DoubleFoo(double) => s"double: $double"
-}
-
-val foo0: Foo = IntFoo.inj(100)
-val foo1: Foo = StringFoo.inj("hello world")
-val foo2: Foo = DoubleFoo.inj(47.6062)
-```
-```scala
-processFoo(foo0)
-// res11: String = int: 100
-
-processFoo(foo1)
-// res12: String = string: hello world
-
-processFoo(foo2)
-// res13: String = double: 47.6062
-```
-
-*coproduct of type constructors*
-
-```scala
-val OptionBar = CopK.Inject[Option, Bar]
-val ListBar   = CopK.Inject[List,   Bar]
-val SeqBar    = CopK.Inject[Seq,    Bar]
-
-def processBar[A](bar: Bar[A]): String = bar match {
-  case OptionBar(option) => s"option: $option"
-  case ListBar(list)     => s"list: $list"
-  case SeqBar(seq)       => s"seq: $seq"
-}
-
-val bar0: Bar[Int]    = OptionBar.inj(Some(200))
-val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
-val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
-```
-```scala
-processBar(bar0)
-// res16: String = option: Some(200)
-
-processBar(bar1)
-// res17: String = list: List(hello, world)
-
-processBar(bar2)
-// res18: String = seq: List(a, b, c)
-```
-
-## Fast Interpreters
-
-If you have interpreters for individual algebras, it's easy to use
-Iota create a fast fan in interpreter for the coproduct of your
-algebras.
-
-You can ask Iota to create a fan in interpreter by explicitly
-passing in individual interpreters for your algebras. Alternatively,
-Iota can implicitly summon the requisite interpreters based off the
-type signature of your desired interpreter.
-
-
-
-
-```scala
-sealed abstract class UserOp[A]
-sealed abstract class OrderOp[A]
-sealed abstract class PriceOp[A]
-
-type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
-
-val evalUserOp : UserOp  ~> Future = dummyInterpreter
-val evalOrderOp: OrderOp ~> Future = dummyInterpreter
-val evalPriceOp: PriceOp ~> Future = dummyInterpreter
-
-// create the interpreter
-
-val evalAlgebra0: Algebra ~> Future = CopK.FunctionK.of(
-  evalUserOp, evalOrderOp, evalPriceOp)
-
-// note: order doesn't matter when creating the interpreter since
-// iota will sort it out for you
-
-val evalAlgebra1: Algebra ~> Future = CopK.FunctionK.of(
-  evalOrderOp, evalPriceOp, evalUserOp)
-
-// if your interpreters are implicitly available, you can summon
-// a fan in interpreter
-
-implicit val _evalUserOp  = evalUserOp
-implicit val _evalOrderOp = evalOrderOp
-implicit val _evalPriceOp = evalPriceOp
-
-val evalAlgebra2: Algebra ~> Future = CopK.FunctionK.summon
-```
-
-The interpreters created by Iota are optimized for speed and have a
-constant evaluation time. Behind the scenes, a macro generates an
-integer based switch statement on the coproduct's internal index value.
-
-If you'd like to see the generated code, toggle the "show trees" option by
-importing `iota.debug.options.ShowTrees` into scope.
-
-```scala
-import iota.debug.options.ShowTrees
-// import iota.debug.options.ShowTrees
-
-CopK.FunctionK.of[Algebra, Future](evalOrderOp, evalPriceOp, evalUserOp)
-// <console>:32: {
-//   class CopKFunctionK$macro$4 extends _root_.iota.internal.FastFunctionK[Algebra, Future] {
-//     private[this] val arr0 = evalUserOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, scala.concurrent.Future]];
-//     private[this] val arr1 = evalOrderOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, scala.concurrent.Future]];
-//     private[this] val arr2 = evalPriceOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, scala.concurrent.Future]];
-//     override def apply[Ξ$](η$: Algebra[Ξ$]): Future[Ξ$] = (η$.index: @_root_.scala.annotation.switch) match {
-//       case 0 => arr0(η$.value)
-//       case 1 => arr1(η$.value)
-//       case 2 => arr2(η$.value)
-//       case (i @ _) => throw new _root_.java.lang.Exception(StringContext("iota internal error: index ").s().+(i).+(" out of bounds for ").+(this)...
-// res33: iota.internal.FastFunctionK[Algebra,scala.concurrent.Future] = FastFunctionK[Algebra, scala.concurrent.Future]<<generated>>
-```
-
-#### Is it actually faster?
-
-Yes. If you look at _just the overhead_ of evaluating the deepest nested
-algebra in a linked list style coproduct, the cost goes up in a linear
-fashion as the coproduct size increase.
-
-This can be seen below using data from Iota's benchmark suite. Here, we
-compare the throughput for using Iota vs Cats for a coproducts up to 25
-element in size. This overhead isn't representative of what you'd encounter
-in real world applications as we are comparing _worst case_ performance with
-the deepest nested type in the coproduct.
-
-![bench](https://cloud.githubusercontent.com/assets/310363/25464097/6b49c0ae-2aaf-11e7-9dc4-3e7d8f0e9267.png)
-
-## Free
-
-A `Free` example is available [in the tests][free example].
+## Documentation
+See [docs/cats.md](docs/cats.md) for the Cats specific documentation and
+[docs/scalaz.md](docs/scalaz.md) for the Scalaz specific documentation.
 
 ## Iota in the wild
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val root = (project in file("."))
   .aggregate(bench)
   .aggregate(corezJVM, corezJS)
   .aggregate(testszJVM, testszJS)
+  .aggregate(readme, docs)
 
 lazy val core = module("core", hideFolder = true)
   .settings(macroSettings)
@@ -90,8 +91,22 @@ lazy val readme = jvmModule("readme")
   .dependsOn(corezJVM)
   .enablePlugins(TutPlugin)
   .settings(noPublishSettings)
-  .settings(readmeSettings)
   .settings(macroSettings)
+  .settings(
+    scalacOptions in Tut := Nil,
+    tutTargetDirectory := (baseDirectory in LocalRootProject).value)
+
+lazy val docs = jvmModule("docs")
+  .dependsOn(coreJVM)
+  .dependsOn(corezJVM)
+  .enablePlugins(TutPlugin)
+  .settings(noPublishSettings)
+  .settings(macroSettings)
+  .settings(
+    scalacOptions in Tut := Nil,
+    tutTargetDirectory := (baseDirectory in LocalRootProject).value / "docs")
+  .settings(libraryDependencies +=
+    "org.scalaz" %% "scalaz-effect" % "7.2.15")
 
 lazy val bench = jvmModule("bench")
   .enablePlugins(JmhPlugin)

--- a/docs/cats.md
+++ b/docs/cats.md
@@ -1,0 +1,167 @@
+iota documentation for Cats
+
+## Coproducts
+
+```scala
+import iota._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+## Injection type classes
+
+Iota provides injection type classes to make it easy to get values in
+and out of your coproducts.
+
+*coproduct of types*
+
+```scala
+val IntFoo    = Cop.Inject[Int,    Foo]
+val StringFoo = Cop.Inject[String, Foo]
+val DoubleFoo = Cop.Inject[Double, Foo]
+
+def processFoo(foo: Foo): String = foo match {
+  case IntFoo(int)       => s"int: $int"
+  case StringFoo(string) => s"string: $string"
+  case DoubleFoo(double) => s"double: $double"
+}
+
+val foo0: Foo = IntFoo.inj(100)
+val foo1: Foo = StringFoo.inj("hello world")
+val foo2: Foo = DoubleFoo.inj(47.6062)
+```
+```scala
+processFoo(foo0)
+// res6: String = int: 100
+
+processFoo(foo1)
+// res7: String = string: hello world
+
+processFoo(foo2)
+// res8: String = double: 47.6062
+```
+
+*coproduct of type constructors*
+
+```scala
+val OptionBar = CopK.Inject[Option, Bar]
+val ListBar   = CopK.Inject[List,   Bar]
+val SeqBar    = CopK.Inject[Seq,    Bar]
+
+def processBar[A](bar: Bar[A]): String = bar match {
+  case OptionBar(option) => s"option: $option"
+  case ListBar(list)     => s"list: $list"
+  case SeqBar(seq)       => s"seq: $seq"
+}
+
+val bar0: Bar[Int]    = OptionBar.inj(Some(200))
+val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
+val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
+```
+```scala
+processBar(bar0)
+// res11: String = option: Some(200)
+
+processBar(bar1)
+// res12: String = list: List(hello, world)
+
+processBar(bar2)
+// res13: String = seq: List(a, b, c)
+```
+
+## Fast Interpreters
+
+If you have interpreters for individual algebras, it's easy to use
+Iota create a fast fan in interpreter for the coproduct of your
+algebras.
+
+You can ask Iota to create a fan in interpreter by explicitly
+passing in individual interpreters for your algebras. Alternatively,
+Iota can implicitly summon the requisite interpreters based off the
+type signature of your desired interpreter.
+
+
+
+
+```scala
+sealed abstract class UserOp[A]
+sealed abstract class OrderOp[A]
+sealed abstract class PriceOp[A]
+
+type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
+
+val evalUserOp : UserOp  ~> Future = dummyInterpreter
+val evalOrderOp: OrderOp ~> Future = dummyInterpreter
+val evalPriceOp: PriceOp ~> Future = dummyInterpreter
+
+// create the interpreter
+
+val evalAlgebra0: Algebra ~> Future = CopK.FunctionK.of(
+  evalUserOp, evalOrderOp, evalPriceOp)
+
+// note: order doesn't matter when creating the interpreter since
+// iota will sort it out for you
+
+val evalAlgebra1: Algebra ~> Future = CopK.FunctionK.of(
+  evalOrderOp, evalPriceOp, evalUserOp)
+
+// if your interpreters are implicitly available, you can summon
+// a fan in interpreter
+
+implicit val _evalUserOp  = evalUserOp
+implicit val _evalOrderOp = evalOrderOp
+implicit val _evalPriceOp = evalPriceOp
+
+val evalAlgebra2: Algebra ~> Future = CopK.FunctionK.summon
+```
+
+The interpreters created by Iota are optimized for speed and have a
+constant evaluation time. Behind the scenes, a macro generates an
+integer based switch statement on the coproduct's internal index value.
+
+If you'd like to see the generated code, toggle the "show trees" option by
+importing `iota.debug.options.ShowTrees` into scope.
+
+```scala
+import iota.debug.options.ShowTrees
+// import iota.debug.options.ShowTrees
+
+CopK.FunctionK.of[Algebra, Future](evalOrderOp, evalPriceOp, evalUserOp)
+// <console>:30: {
+//   class CopKFunctionK$macro$4 extends _root_.iota.internal.FastFunctionK[Algebra, Future] {
+//     private[this] val arr0 = evalUserOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, scala.concurrent.Future]];
+//     private[this] val arr1 = evalOrderOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, scala.concurrent.Future]];
+//     private[this] val arr2 = evalPriceOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, scala.concurrent.Future]];
+//     override def apply[Ξ$](η$: Algebra[Ξ$]): Future[Ξ$] = (η$.index: @_root_.scala.annotation.switch) match {
+//       case 0 => arr0(η$.value)
+//       case 1 => arr1(η$.value)
+//       case 2 => arr2(η$.value)
+//       case (i @ _) => throw new _root_.java.lang.Exception(StringContext("iota internal error: index ").s().+(i).+(" out of bounds for ")...
+// res28: iota.internal.FastFunctionK[Algebra,scala.concurrent.Future] = FastFunctionK[Algebra, scala.concurrent.Future]<<generated>>
+```
+
+#### Is it actually faster?
+
+Yes. If you look at _just the overhead_ of evaluating the deepest nested
+algebra in a linked list style coproduct, the cost goes up in a linear
+fashion as the coproduct size increase.
+
+This can be seen below using data from Iota's benchmark suite. Here, we
+compare the throughput for using Iota vs Cats for a coproducts up to 25
+element in size. This overhead isn't representative of what you'd encounter
+in real world applications as we are comparing _worst case_ performance with
+the deepest nested type in the coproduct.
+
+![bench](https://cloud.githubusercontent.com/assets/310363/25464097/6b49c0ae-2aaf-11e7-9dc4-3e7d8f0e9267.png)
+
+## Free
+
+A `Free` example is available [in the tests][free example].
+
+[free example]: modules/tests/src/test/scala/iotatests/FreeCopKTests.scala

--- a/docs/scalaz.md
+++ b/docs/scalaz.md
@@ -1,0 +1,152 @@
+iota documentation for Scalaz
+
+## Coproducts
+
+```scala
+import iotaz._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+## Injection type classes
+
+Iota provides injection type classes to make it easy to get values in
+and out of your coproducts.
+
+*coproduct of types*
+
+```scala
+val IntFoo    = Cop.Inject[Int,    Foo]
+val StringFoo = Cop.Inject[String, Foo]
+val DoubleFoo = Cop.Inject[Double, Foo]
+
+def processFoo(foo: Foo): String = foo match {
+  case IntFoo(int)       => s"int: $int"
+  case StringFoo(string) => s"string: $string"
+  case DoubleFoo(double) => s"double: $double"
+}
+
+val foo0: Foo = IntFoo.inj(100)
+val foo1: Foo = StringFoo.inj("hello world")
+val foo2: Foo = DoubleFoo.inj(47.6062)
+```
+```scala
+processFoo(foo0)
+// res6: String = int: 100
+
+processFoo(foo1)
+// res7: String = string: hello world
+
+processFoo(foo2)
+// res8: String = double: 47.6062
+```
+
+*coproduct of type constructors*
+
+```scala
+val OptionBar = CopK.Inject[Option, Bar]
+val ListBar   = CopK.Inject[List,   Bar]
+val SeqBar    = CopK.Inject[Seq,    Bar]
+
+def processBar[A](bar: Bar[A]): String = bar match {
+  case OptionBar(option) => s"option: $option"
+  case ListBar(list)     => s"list: $list"
+  case SeqBar(seq)       => s"seq: $seq"
+}
+
+val bar0: Bar[Int]    = OptionBar.inj(Some(200))
+val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
+val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
+```
+```scala
+processBar(bar0)
+// res11: String = option: Some(200)
+
+processBar(bar1)
+// res12: String = list: List(hello, world)
+
+processBar(bar2)
+// res13: String = seq: List(a, b, c)
+```
+
+## Fast Interpreters
+
+If you have interpreters for individual algebras, it's easy to use
+Iota create a fast fan in interpreter for the coproduct of your
+algebras.
+
+You can ask Iota to create a fan in interpreter by explicitly
+passing in individual interpreters for your algebras. Alternatively,
+Iota can implicitly summon the requisite interpreters based off the
+type signature of your desired interpreter.
+
+One thing to note: `NaturalTransformation` in Scalaz is defined using
+variance which doesn't work well with macros that need to infer types.
+Consequently some iota methods (`of` and `summon`) require that type
+parameters are specified.
+
+
+
+
+```scala
+sealed abstract class UserOp[A]
+sealed abstract class OrderOp[A]
+sealed abstract class PriceOp[A]
+
+type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
+
+val evalUserOp : UserOp  ~> IO = dummyInterpreter
+val evalOrderOp: OrderOp ~> IO = dummyInterpreter
+val evalPriceOp: PriceOp ~> IO = dummyInterpreter
+
+// create the interpreter
+
+val evalAlgebra0: Algebra ~> IO = CopK.NaturalTransformation.of[Algebra, IO](
+  evalUserOp, evalOrderOp, evalPriceOp)
+
+// note: order doesn't matter when creating the interpreter since
+// iota will sort it out for you
+
+val evalAlgebra1: Algebra ~> IO = CopK.NaturalTransformation.of[Algebra, IO](
+  evalOrderOp, evalPriceOp, evalUserOp)
+
+// if your interpreters are implicitly available, you can summon
+// a fan in interpreter
+
+implicit val _evalUserOp  = evalUserOp
+implicit val _evalOrderOp = evalOrderOp
+implicit val _evalPriceOp = evalPriceOp
+
+val evalAlgebra2: Algebra ~> IO = CopK.NaturalTransformation.summon[Algebra, IO]
+```
+
+The interpreters created by Iota are optimized for speed and have a
+constant evaluation time. Behind the scenes, a macro generates an
+integer based switch statement on the coproduct's internal index value.
+
+If you'd like to see the generated code, toggle the "show trees" option by
+importing `iota.debug.options.ShowTrees` into scope.
+
+```scala
+import iotaz.debug.options.ShowTrees
+// import iotaz.debug.options.ShowTrees
+
+CopK.NaturalTransformation.of[Algebra, IO](evalOrderOp, evalPriceOp, evalUserOp)
+// <console>:32: {
+//   class CopKNaturalTransformation$macro$4 extends _root_.iotaz.internal.FastNaturalTransformation[Algebra, IO] {
+//     private[this] val arr0 = evalUserOp.asInstanceOf[_root_.scalaz.NaturalTransformation[Any, scalaz.effect.IO]];
+//     private[this] val arr1 = evalOrderOp.asInstanceOf[_root_.scalaz.NaturalTransformation[Any, scalaz.effect.IO]];
+//     private[this] val arr2 = evalPriceOp.asInstanceOf[_root_.scalaz.NaturalTransformation[Any, scalaz.effect.IO]];
+//     override def apply[Ξ$](η$: Algebra[Ξ$]): IO[Ξ$] = (η$.index: @_root_.scala.annotation.switch) match {
+//       case 0 => arr0(η$.value)
+//       case 1 => arr1(η$.value)
+//       case 2 => arr2(η$.value)
+//       case (i @ _) => throw new _root_.java.lang.Exception(StringContext("iota internal error: index ").s().+(i).+(" ...
+// res28: iotaz.internal.FastNaturalTransformation[Algebra,scalaz.effect.IO] = FastFunctionK[Algebra, scalaz.effect.IO]<<generated>>
+```

--- a/docs/scalaz.md.bak
+++ b/docs/scalaz.md.bak
@@ -1,0 +1,130 @@
+iota documentation for Scalaz
+
+## Coproducts
+
+```tut:silent
+import iotaz._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+## Injection type classes
+
+Iota provides injection type classes to make it easy to get values in
+and out of your coproducts.
+
+*coproduct of types*
+
+```tut:silent
+val IntFoo    = Cop.Inject[Int,    Foo]
+val StringFoo = Cop.Inject[String, Foo]
+val DoubleFoo = Cop.Inject[Double, Foo]
+
+def processFoo(foo: Foo): String = foo match {
+  case IntFoo(int)       => s"int: $int"
+  case StringFoo(string) => s"string: $string"
+  case DoubleFoo(double) => s"double: $double"
+}
+
+val foo0: Foo = IntFoo.inj(100)
+val foo1: Foo = StringFoo.inj("hello world")
+val foo2: Foo = DoubleFoo.inj(47.6062)
+```
+```tut:book
+processFoo(foo0)
+processFoo(foo1)
+processFoo(foo2)
+```
+
+*coproduct of type constructors*
+
+```tut:silent
+val OptionBar = CopK.Inject[Option, Bar]
+val ListBar   = CopK.Inject[List,   Bar]
+val SeqBar    = CopK.Inject[Seq,    Bar]
+
+def processBar[A](bar: Bar[A]): String = bar match {
+  case OptionBar(option) => s"option: $option"
+  case ListBar(list)     => s"list: $list"
+  case SeqBar(seq)       => s"seq: $seq"
+}
+
+val bar0: Bar[Int]    = OptionBar.inj(Some(200))
+val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
+val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
+```
+```tut:book
+processBar(bar0)
+processBar(bar1)
+processBar(bar2)
+```
+
+## Fast Interpreters
+
+If you have interpreters for individual algebras, it's easy to use
+Iota create a fast fan in interpreter for the coproduct of your
+algebras.
+
+You can ask Iota to create a fan in interpreter by explicitly
+passing in individual interpreters for your algebras. Alternatively,
+Iota can implicitly summon the requisite interpreters based off the
+type signature of your desired interpreter.
+
+```tut:invisible
+import scalaz._
+import scalaz.effect._
+
+def dummyInterpreter[F[_]]: F ~> IO = new (F ~> IO) {
+  override def apply[A](fa: F[A]): IO[A] = ???
+}
+```
+
+```tut:silent
+sealed abstract class UserOp[A]
+sealed abstract class OrderOp[A]
+sealed abstract class PriceOp[A]
+
+type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
+
+val evalUserOp : UserOp  ~> IO = dummyInterpreter
+val evalOrderOp: OrderOp ~> IO = dummyInterpreter
+val evalPriceOp: PriceOp ~> IO = dummyInterpreter
+
+// create the interpreter
+
+val evalAlgebra0: Algebra ~> IO = CopK.NaturalTransformation.of(
+  evalUserOp, evalOrderOp, evalPriceOp)
+
+// note: order doesn't matter when creating the interpreter since
+// iota will sort it out for you
+
+val evalAlgebra1: Algebra ~> IO = CopK.NaturalTransformation.of(
+  evalOrderOp, evalPriceOp, evalUserOp)
+
+// if your interpreters are implicitly available, you can summon
+// a fan in interpreter
+
+implicit val _evalUserOp  = evalUserOp
+implicit val _evalOrderOp = evalOrderOp
+implicit val _evalPriceOp = evalPriceOp
+
+val evalAlgebra2: Algebra ~> IO = CopK.NaturalTransformation.summon
+```
+
+The interpreters created by Iota are optimized for speed and have a
+constant evaluation time. Behind the scenes, a macro generates an
+integer based switch statement on the coproduct's internal index value.
+
+If you'd like to see the generated code, toggle the "show trees" option by
+importing `iota.debug.options.ShowTrees` into scope.
+
+```tut:book
+import iotaz.debug.options.ShowTrees
+CopK.NaturalTransformation.of[Algebra, IO](evalOrderOp, evalPriceOp, evalUserOp)
+```

--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -31,6 +31,8 @@ object Cop {
     //#+scalaz
     def inj: A => B
     def prj: B => Option[A]
+    final def apply(a: A): B = inj(a)
+    final def unapply(b: B): Option[A] = prj(b)
     //#-scalaz
   }
 

--- a/modules/core/src/main/scala/iota/CopK.scala
+++ b/modules/core/src/main/scala/iota/CopK.scala
@@ -34,6 +34,8 @@ object CopK {
     //#+scalaz
     def inj: F ~> G
     def prj: G ~> λ[α => Option[F[α]]]
+    final def apply[A](fa: F[A]): G[A] = inj(fa)
+    final def unapply[A](ga: G[A]): Option[F[A]] = prj(ga)
     //#-scalaz
   }
 

--- a/modules/docs/src/main/tut/cats.md
+++ b/modules/docs/src/main/tut/cats.md
@@ -1,0 +1,150 @@
+iota documentation for Cats
+
+## Coproducts
+
+```tut:silent
+import iota._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+## Injection type classes
+
+Iota provides injection type classes to make it easy to get values in
+and out of your coproducts.
+
+*coproduct of types*
+
+```tut:silent
+val IntFoo    = Cop.Inject[Int,    Foo]
+val StringFoo = Cop.Inject[String, Foo]
+val DoubleFoo = Cop.Inject[Double, Foo]
+
+def processFoo(foo: Foo): String = foo match {
+  case IntFoo(int)       => s"int: $int"
+  case StringFoo(string) => s"string: $string"
+  case DoubleFoo(double) => s"double: $double"
+}
+
+val foo0: Foo = IntFoo.inj(100)
+val foo1: Foo = StringFoo.inj("hello world")
+val foo2: Foo = DoubleFoo.inj(47.6062)
+```
+```tut:book
+processFoo(foo0)
+processFoo(foo1)
+processFoo(foo2)
+```
+
+*coproduct of type constructors*
+
+```tut:silent
+val OptionBar = CopK.Inject[Option, Bar]
+val ListBar   = CopK.Inject[List,   Bar]
+val SeqBar    = CopK.Inject[Seq,    Bar]
+
+def processBar[A](bar: Bar[A]): String = bar match {
+  case OptionBar(option) => s"option: $option"
+  case ListBar(list)     => s"list: $list"
+  case SeqBar(seq)       => s"seq: $seq"
+}
+
+val bar0: Bar[Int]    = OptionBar.inj(Some(200))
+val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
+val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
+```
+```tut:book
+processBar(bar0)
+processBar(bar1)
+processBar(bar2)
+```
+
+## Fast Interpreters
+
+If you have interpreters for individual algebras, it's easy to use
+Iota create a fast fan in interpreter for the coproduct of your
+algebras.
+
+You can ask Iota to create a fan in interpreter by explicitly
+passing in individual interpreters for your algebras. Alternatively,
+Iota can implicitly summon the requisite interpreters based off the
+type signature of your desired interpreter.
+
+```tut:invisible
+import scala.concurrent.Future
+import cats._
+
+def dummyInterpreter[F[_]]: F ~> Future = new (F ~> Future) {
+  override def apply[A](fa: F[A]): Future[A] = ???
+}
+```
+
+```tut:silent
+sealed abstract class UserOp[A]
+sealed abstract class OrderOp[A]
+sealed abstract class PriceOp[A]
+
+type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
+
+val evalUserOp : UserOp  ~> Future = dummyInterpreter
+val evalOrderOp: OrderOp ~> Future = dummyInterpreter
+val evalPriceOp: PriceOp ~> Future = dummyInterpreter
+
+// create the interpreter
+
+val evalAlgebra0: Algebra ~> Future = CopK.FunctionK.of(
+  evalUserOp, evalOrderOp, evalPriceOp)
+
+// note: order doesn't matter when creating the interpreter since
+// iota will sort it out for you
+
+val evalAlgebra1: Algebra ~> Future = CopK.FunctionK.of(
+  evalOrderOp, evalPriceOp, evalUserOp)
+
+// if your interpreters are implicitly available, you can summon
+// a fan in interpreter
+
+implicit val _evalUserOp  = evalUserOp
+implicit val _evalOrderOp = evalOrderOp
+implicit val _evalPriceOp = evalPriceOp
+
+val evalAlgebra2: Algebra ~> Future = CopK.FunctionK.summon
+```
+
+The interpreters created by Iota are optimized for speed and have a
+constant evaluation time. Behind the scenes, a macro generates an
+integer based switch statement on the coproduct's internal index value.
+
+If you'd like to see the generated code, toggle the "show trees" option by
+importing `iota.debug.options.ShowTrees` into scope.
+
+```tut:book
+import iota.debug.options.ShowTrees
+CopK.FunctionK.of[Algebra, Future](evalOrderOp, evalPriceOp, evalUserOp)
+```
+
+#### Is it actually faster?
+
+Yes. If you look at _just the overhead_ of evaluating the deepest nested
+algebra in a linked list style coproduct, the cost goes up in a linear
+fashion as the coproduct size increase.
+
+This can be seen below using data from Iota's benchmark suite. Here, we
+compare the throughput for using Iota vs Cats for a coproducts up to 25
+element in size. This overhead isn't representative of what you'd encounter
+in real world applications as we are comparing _worst case_ performance with
+the deepest nested type in the coproduct.
+
+![bench](https://cloud.githubusercontent.com/assets/310363/25464097/6b49c0ae-2aaf-11e7-9dc4-3e7d8f0e9267.png)
+
+## Free
+
+A `Free` example is available [in the tests][free example].
+
+[free example]: modules/tests/src/test/scala/iotatests/FreeCopKTests.scala

--- a/modules/docs/src/main/tut/scalaz.md
+++ b/modules/docs/src/main/tut/scalaz.md
@@ -1,0 +1,135 @@
+iota documentation for Scalaz
+
+## Coproducts
+
+```tut:silent
+import iotaz._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+## Injection type classes
+
+Iota provides injection type classes to make it easy to get values in
+and out of your coproducts.
+
+*coproduct of types*
+
+```tut:silent
+val IntFoo    = Cop.Inject[Int,    Foo]
+val StringFoo = Cop.Inject[String, Foo]
+val DoubleFoo = Cop.Inject[Double, Foo]
+
+def processFoo(foo: Foo): String = foo match {
+  case IntFoo(int)       => s"int: $int"
+  case StringFoo(string) => s"string: $string"
+  case DoubleFoo(double) => s"double: $double"
+}
+
+val foo0: Foo = IntFoo.inj(100)
+val foo1: Foo = StringFoo.inj("hello world")
+val foo2: Foo = DoubleFoo.inj(47.6062)
+```
+```tut:book
+processFoo(foo0)
+processFoo(foo1)
+processFoo(foo2)
+```
+
+*coproduct of type constructors*
+
+```tut:silent
+val OptionBar = CopK.Inject[Option, Bar]
+val ListBar   = CopK.Inject[List,   Bar]
+val SeqBar    = CopK.Inject[Seq,    Bar]
+
+def processBar[A](bar: Bar[A]): String = bar match {
+  case OptionBar(option) => s"option: $option"
+  case ListBar(list)     => s"list: $list"
+  case SeqBar(seq)       => s"seq: $seq"
+}
+
+val bar0: Bar[Int]    = OptionBar.inj(Some(200))
+val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
+val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
+```
+```tut:book
+processBar(bar0)
+processBar(bar1)
+processBar(bar2)
+```
+
+## Fast Interpreters
+
+If you have interpreters for individual algebras, it's easy to use
+Iota create a fast fan in interpreter for the coproduct of your
+algebras.
+
+You can ask Iota to create a fan in interpreter by explicitly
+passing in individual interpreters for your algebras. Alternatively,
+Iota can implicitly summon the requisite interpreters based off the
+type signature of your desired interpreter.
+
+One thing to note: `NaturalTransformation` in Scalaz is defined using
+variance which doesn't work well with macros that need to infer types.
+Consequently some iota methods (`of` and `summon`) require that type
+parameters are specified.
+
+```tut:invisible
+import scalaz._
+import scalaz.effect._
+
+def dummyInterpreter[F[_]]: F ~> IO = new (F ~> IO) {
+  override def apply[A](fa: F[A]): IO[A] = ???
+}
+```
+
+```tut:silent
+sealed abstract class UserOp[A]
+sealed abstract class OrderOp[A]
+sealed abstract class PriceOp[A]
+
+type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
+
+val evalUserOp : UserOp  ~> IO = dummyInterpreter
+val evalOrderOp: OrderOp ~> IO = dummyInterpreter
+val evalPriceOp: PriceOp ~> IO = dummyInterpreter
+
+// create the interpreter
+
+val evalAlgebra0: Algebra ~> IO = CopK.NaturalTransformation.of[Algebra, IO](
+  evalUserOp, evalOrderOp, evalPriceOp)
+
+// note: order doesn't matter when creating the interpreter since
+// iota will sort it out for you
+
+val evalAlgebra1: Algebra ~> IO = CopK.NaturalTransformation.of[Algebra, IO](
+  evalOrderOp, evalPriceOp, evalUserOp)
+
+// if your interpreters are implicitly available, you can summon
+// a fan in interpreter
+
+implicit val _evalUserOp  = evalUserOp
+implicit val _evalOrderOp = evalOrderOp
+implicit val _evalPriceOp = evalPriceOp
+
+val evalAlgebra2: Algebra ~> IO = CopK.NaturalTransformation.summon[Algebra, IO]
+```
+
+The interpreters created by Iota are optimized for speed and have a
+constant evaluation time. Behind the scenes, a macro generates an
+integer based switch statement on the coproduct's internal index value.
+
+If you'd like to see the generated code, toggle the "show trees" option by
+importing `iota.debug.options.ShowTrees` into scope.
+
+```tut:book
+import iotaz.debug.options.ShowTrees
+CopK.NaturalTransformation.of[Algebra, IO](evalOrderOp, evalPriceOp, evalUserOp)
+```

--- a/modules/examples-scalaz/src/main/scala/example/FreeExample.scala
+++ b/modules/examples-scalaz/src/main/scala/example/FreeExample.scala
@@ -6,8 +6,6 @@ import scalaz._
 import scalaz.effect._
 import scalaz.syntax.apply._
 
-import scala.Predef._
-
 sealed trait TerminalOp[A]
 object TerminalOp {
   case object ReadLine extends TerminalOp[String]
@@ -43,11 +41,11 @@ object FreeExample extends SafeApp {
     }
 
   val stateToProgram = λ[State[Long, ?] ~> Program](_.mapT(v => IO(v)))
-  val ioToProgram    = λ[IO ~> Program](io => StateT(s => io.map(s -> _)))
-  val interpreter: Algebra ~> Program =
+  val ioToProgram    = λ[IO ~> Program](io => StateT(s => io.map((s, _))))
+  val interpreter: scalaz.NaturalTransformation[Algebra, Program] =
     CopK.NaturalTransformation.of[Algebra, Program](
-      counterToState andThen stateToProgram,
-      terminalToIO andThen ioToProgram)
+      terminalToIO andThen ioToProgram,
+      counterToState andThen stateToProgram)
 
   implicit class AlgebraSyntax[F[_], A](fa: F[A])(
     implicit ev: CopK.Inject[F, Algebra]

--- a/modules/readme/src/main/tut/README.md
+++ b/modules/readme/src/main/tut/README.md
@@ -1,4 +1,10 @@
 
+[comment]: # (Start Badges)
+
+[![Build Status](https://travis-ci.org/frees-io/iota.svg?branch=master)](https://travis-ci.org/frees-io/iota) [![Maven Central](https://img.shields.io/badge/maven%20central-0.3.2-green.svg)](https://oss.sonatype.org/#nexus-search;gav~io.frees~iota*) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/frees-io/iota/master/LICENSE) [![Latest version](https://img.shields.io/badge/iota-0.3.2-green.svg)](https://index.scala-lang.org/frees-io/iota) [![Scala.js](http://scala-js.org/assets/badges/scalajs-0.6.20.svg)](http://scala-js.org) [![GitHub Issues](https://img.shields.io/github/issues/frees-io/iota.svg)](https://github.com/frees-io/iota/issues)
+
+[comment]: # (End Badges)
+
 # Iota
 
 ## Introduction
@@ -18,12 +24,12 @@ type EitherFoo = Either[Int, Either[String, Double]]
 // a coproduct of type constructors using cats.data.EitherK
 import cats.data.EitherK
 type EitherKBar0[A] = EitherK[List, Seq, A]
-type EitherKBar[A] = EitherK[Option, EitherKBar0, A]
+type EitherKBar[A]  = EitherK[Option, EitherKBar0, A]
 
 // a coproduct of type constructors using scalaz.Coproduct
 import scalaz.Coproduct
 type CoproductKBar0[A] = Coproduct[List, Seq, A]
-type CoproductKBar[A] = Coproduct[Option, CoproductKBar0, A]
+type CoproductKBar[A]  = Coproduct[Option, CoproductKBar0, A]
 ```
 
 Iota coproducts are linked lists at the type level. At the value level,
@@ -32,7 +38,21 @@ constant time access of the values. This syntax scales cleanly to
 support any number of disjunct types.
 
 ```tut:silent
-import iota._ // or iotaz._
+// for cats
+import iota._
+import TList.::
+import TListK.:::
+
+// a coproduct of types
+type Foo = Cop[Int :: String :: Double :: TNil]
+
+// a coproduct of type constructors
+type Bar[A] = CopK[Option ::: List ::: Seq ::: TNilK, A]
+```
+
+```tut:reset:silent
+// for scalaz
+import iotaz._
 import TList.::
 import TListK.:::
 
@@ -79,138 +99,9 @@ The Cats examples will work against Scalaz, and vise versa, so long as the
 library specific terminology is adjusted. Expect more Scalaz examples as the
 Iota library evolves.
 
-## Injection type classes
-
-Iota provides injection type classes to make it easy to get values in
-and out of your coproducts.
-
-*coproduct of types*
-
-```tut:silent
-val IntFoo    = Cop.Inject[Int,    Foo]
-val StringFoo = Cop.Inject[String, Foo]
-val DoubleFoo = Cop.Inject[Double, Foo]
-
-def processFoo(foo: Foo): String = foo match {
-  case IntFoo(int)       => s"int: $int"
-  case StringFoo(string) => s"string: $string"
-  case DoubleFoo(double) => s"double: $double"
-}
-
-val foo0: Foo = IntFoo.inj(100)
-val foo1: Foo = StringFoo.inj("hello world")
-val foo2: Foo = DoubleFoo.inj(47.6062)
-```
-```tut:book
-processFoo(foo0)
-processFoo(foo1)
-processFoo(foo2)
-```
-
-*coproduct of type constructors*
-
-```tut:silent
-val OptionBar = CopK.Inject[Option, Bar]
-val ListBar   = CopK.Inject[List,   Bar]
-val SeqBar    = CopK.Inject[Seq,    Bar]
-
-def processBar[A](bar: Bar[A]): String = bar match {
-  case OptionBar(option) => s"option: $option"
-  case ListBar(list)     => s"list: $list"
-  case SeqBar(seq)       => s"seq: $seq"
-}
-
-val bar0: Bar[Int]    = OptionBar.inj(Some(200))
-val bar1: Bar[String] = ListBar.inj("hello" :: "world" :: Nil)
-val bar2: Bar[String] = SeqBar.inj(Seq("a", "b", "c"))
-```
-```tut:book
-processBar(bar0)
-processBar(bar1)
-processBar(bar2)
-```
-
-## Fast Interpreters
-
-If you have interpreters for individual algebras, it's easy to use
-Iota create a fast fan in interpreter for the coproduct of your
-algebras.
-
-You can ask Iota to create a fan in interpreter by explicitly
-passing in individual interpreters for your algebras. Alternatively,
-Iota can implicitly summon the requisite interpreters based off the
-type signature of your desired interpreter.
-
-```tut:invisible
-import scala.concurrent.Future
-import cats._
-
-def dummyInterpreter[F[_]]: F ~> Future = new (F ~> Future) {
-  override def apply[A](fa: F[A]): Future[A] = ???
-}
-```
-
-```tut:silent
-sealed abstract class UserOp[A]
-sealed abstract class OrderOp[A]
-sealed abstract class PriceOp[A]
-
-type Algebra[A] = CopK[UserOp ::: OrderOp ::: PriceOp ::: TNilK, A]
-
-val evalUserOp : UserOp  ~> Future = dummyInterpreter
-val evalOrderOp: OrderOp ~> Future = dummyInterpreter
-val evalPriceOp: PriceOp ~> Future = dummyInterpreter
-
-// create the interpreter
-
-val evalAlgebra0: Algebra ~> Future = CopK.FunctionK.of(
-  evalUserOp, evalOrderOp, evalPriceOp)
-
-// note: order doesn't matter when creating the interpreter since
-// iota will sort it out for you
-
-val evalAlgebra1: Algebra ~> Future = CopK.FunctionK.of(
-  evalOrderOp, evalPriceOp, evalUserOp)
-
-// if your interpreters are implicitly available, you can summon
-// a fan in interpreter
-
-implicit val _evalUserOp  = evalUserOp
-implicit val _evalOrderOp = evalOrderOp
-implicit val _evalPriceOp = evalPriceOp
-
-val evalAlgebra2: Algebra ~> Future = CopK.FunctionK.summon
-```
-
-The interpreters created by Iota are optimized for speed and have a
-constant evaluation time. Behind the scenes, a macro generates an
-integer based switch statement on the coproduct's internal index value.
-
-If you'd like to see the generated code, toggle the "show trees" option by
-importing `iota.debug.options.ShowTrees` into scope.
-
-```tut:book
-import iota.debug.options.ShowTrees
-CopK.FunctionK.of[Algebra, Future](evalOrderOp, evalPriceOp, evalUserOp)
-```
-
-#### Is it actually faster?
-
-Yes. If you look at _just the overhead_ of evaluating the deepest nested
-algebra in a linked list style coproduct, the cost goes up in a linear
-fashion as the coproduct size increase.
-
-This can be seen below using data from Iota's benchmark suite. Here, we
-compare the throughput for using Iota vs Cats for a coproducts up to 25
-element in size. This overhead isn't representative of what you'd encounter
-in real world applications as we are comparing _worst case_ performance with
-the deepest nested type in the coproduct.
-
-![bench](https://cloud.githubusercontent.com/assets/310363/25464097/6b49c0ae-2aaf-11e7-9dc4-3e7d8f0e9267.png)
-
-## Free
-
-A `Free` example is available [in the tests][free example].
+## Documentation
+See [docs/cats.md](docs/cats.md) for the Cats specific documentation and
+[docs/scalaz.md](docs/scalaz.md) for the Scalaz specific documentation.
 
 ## Iota in the wild
 

--- a/modules/tests/src/test/scala/iotatests/CopKFunctionKTests.scala
+++ b/modules/tests/src/test/scala/iotatests/CopKFunctionKTests.scala
@@ -25,4 +25,9 @@ object CopKFunctionKTests {
     }
 
   CopKNT.summon[CopK[FooOp :: BarOp :: TNilK, ?], Either[String, ?]]
+
+  //#+cats
+  val res0: CopK[FooOp :: BarOp :: TNilK, ?] ~> Either[String, ?] =
+    CopKNT.summon
+  //#-cats
 }

--- a/modules/tests/src/test/scala/iotatests/CopKTests.scala
+++ b/modules/tests/src/test/scala/iotatests/CopKTests.scala
@@ -109,12 +109,11 @@ object CopKTests extends Properties("CopKTests") {
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
     Last ::
     TNilK
-
 
   property("inject First into Yuge") =
     checkInjectL(

--- a/modules/tests/src/test/scala/iotatests/CopKTests.scala
+++ b/modules/tests/src/test/scala/iotatests/CopKTests.scala
@@ -86,6 +86,7 @@ object CopKTests extends Properties("CopKTests") {
       CopK.InjectL[Three, Reverse[ThreeTwoOneL]],
       2)
 
+  //#+cats
   type First[A] = String
   type Last[A] = A
   type Y[A]
@@ -126,4 +127,5 @@ object CopKTests extends Properties("CopKTests") {
       arbitrary[Last[Int]],
       CopK.InjectL[Last, Yuge],
       301)
+  //#-cats
 }

--- a/modules/tests/src/test/scala/iotatests/CopKTests.scala
+++ b/modules/tests/src/test/scala/iotatests/CopKTests.scala
@@ -109,9 +109,9 @@ object CopKTests extends Properties("CopKTests") {
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Last ::
     TNilK
 

--- a/modules/tests/src/test/scala/iotatests/CopTests.scala
+++ b/modules/tests/src/test/scala/iotatests/CopTests.scala
@@ -75,6 +75,7 @@ object CopTests extends Properties("CopTests") {
       Cop.InjectL[Three, Reverse[ThreeTwoOneL]],
       2)
 
+  //#+cats
   type First = Int
   type Last  = String
   type Y
@@ -98,9 +99,9 @@ object CopTests extends Properties("CopTests") {
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Last ::
     TNil
 
@@ -116,4 +117,5 @@ object CopTests extends Properties("CopTests") {
       arbitrary[Last],
       Cop.InjectL[Last, Yuge],
       301)
+  //#-cats
 }

--- a/modules/tests/src/test/scala/iotatests/CopTests.scala
+++ b/modules/tests/src/test/scala/iotatests/CopTests.scala
@@ -98,9 +98,9 @@ object CopTests extends Properties("CopTests") {
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
     Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
-    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y ::
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
+    Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: Y :: //#=cats
     Last ::
     TNil
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -34,13 +34,6 @@ object ProjectPlugin extends AutoPlugin {
     def jvmModule(modName: String): Project =
       Project(modName, file(s"""modules/$modName"""))
         .settings(moduleName := s"iota-$modName")
-
-    lazy val readmeSettings: Seq[Def.Setting[_]] = Seq(
-      scalacOptions in Tut := Nil,
-      tutSourceDirectory :=
-        (baseDirectory in LocalRootProject).value / "modules" / "readme" / "src" / "main" / "tut",
-      tutTargetDirectory := baseDirectory.value.getParentFile.getParentFile
-    )
   }
 
   lazy val commandAliases: Seq[Def.Setting[_]] = addCommandAlias("tutReadme", ";project readme;tut;project root")


### PR DESCRIPTION
There are a few remaining fixes in the tests to get the build green, but:

- Split the README into separate docs for Cats / Scalaz
- Add guards for alerting users of the slight issue with Scalaz's variances on `NaturalTransformation`.
- "Fix" Scalaz support

**_Fixing Scalaz support_**

There was one big issue related to type inferencing for the parameters on `CopK.NaturalTransformation.of/summon`. After a bit of debugging while at SBTB I've sorted out what seems to be the best solution.

The short story is that the variances on Scalaz's NaturalTransformation cause the typer to simply assume `Nothing` (or use an existential type) instead of computing a type tag. A potential solution was posted on SO several years ago, but this doesn't work for this use case.

For the time being, Scalaz users will need to specify the type parameters when calling . If variances are removed from Scalaz, then this requirement should seamlessly disappear.

Thanks to @propensive for macro debugging assistance and @jdegoes for Scalaz roadmap discussion.