### PR TITLE
Add first item evidence for CopK

### DIFF
--- a/modules/core/src/main/scala/iota/evidence.scala
+++ b/modules/core/src/main/scala/iota/evidence.scala
@@ -1,0 +1,13 @@
+package iota  //#=cats
+package iotaz //#=scalaz
+package evidence
+
+final class FirstK[L <: TListK, A](val underlying: CopK[L, A]) extends AnyVal
+
+object FirstK {
+  def apply[L <: TListK, A](implicit ev: FirstK[L, A]): FirstK[L, A] = ev
+
+  implicit def materializeFirstK[L <: TListK, A]: FirstK[L, A] =
+    macro internal.EvidenceMacros.materializeFirstK[L, A]
+
+}

--- a/modules/core/src/main/scala/iota/internal/EvidenceMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/EvidenceMacros.scala
@@ -1,0 +1,67 @@
+package iota  //#=cats
+package iotaz //#=scalaz
+package internal
+
+import evidence._
+
+//#+cats
+import cats._
+import cats.data._
+import cats.instances.all._
+import cats.syntax.either._ //#=2.12
+//#-cats
+
+//#+scalaz
+import scalaz._
+import Scalaz._
+//#-scalaz
+
+import scala.reflect.macros.whitebox.Context
+import scala.reflect.macros.TypecheckException
+
+final class EvidenceMacros(val c: Context) {
+  import c.universe._
+
+  private[this] val tb = IotaMacroToolbelt(c)
+
+  def materializeFirstK[L <: TListK, A](
+    implicit
+      evL: c.WeakTypeTag[L],
+      evA: c.WeakTypeTag[A]
+  ): c.Expr[FirstK[L, A]] = {
+
+    val L = evL.tpe
+    val A = evA.tpe
+
+    type Acc = Either[List[String], (Type, Int, Tree)]
+
+    tb.foldAbort(for {
+      tpes <- tb.memoizedTListKTypes(L).leftMap(List(_))
+      tup3 <- tpes.foldLeft(Left(Nil): Acc)((acc, F) =>
+          acc match {
+            case Left(e) => summonEvidence(F, A).leftMap(_ :: e).map(fa => (F, e.length, fa))
+            case other => other
+          })
+      (_F, index, fa) = tup3
+    } yield
+      q"new ${tb.iotaPackage}.evidence.FirstK[$L, $A](${makeCopK(L, _F, A, index, fa)})")
+  }
+
+  private[this] def makeCopK(
+    L: Type,
+    F: Type,
+    A: Type,
+    index: Int,
+    fa: Tree
+  ): Tree =
+    q"${tb.iotaPackage}.CopK.unsafeApply[$L, $F, $A]($index, $fa)"
+
+  private[this] def summonEvidence(F: Type, A: Type): Either[String, Tree] =
+    Avowal
+      .catching[TypecheckException](
+        c.typecheck(
+          q"_root_.scala.Predef.implicitly[${appliedType(F, A)}]"))
+      .leftMap(t => t.msg)
+      .toEither
+
+}

--- a/modules/core/src/main/scala/iota/syntax/helpers.scala
+++ b/modules/core/src/main/scala/iota/syntax/helpers.scala
@@ -2,6 +2,14 @@ package iota  //#=cats
 package iotaz //#=scalaz
 package syntax
 
+import iota.evidence._  //#=cats
+import iotaz.evidence._ //#=scalaz
+
+trait EvidenceSyntax {
+  def firstK[L <: TListK, A](implicit ev: FirstK[L, A]): CopK[L, A] =
+    ev.underlying
+}
+
 final class InjectOps[A](val a: A) extends AnyVal {
   def inject[B <: Cop[_]](implicit ev: Cop.Inject[A, B]): B =
     ev.inj(a)

--- a/modules/core/src/main/scala/iota/syntax/package.scala
+++ b/modules/core/src/main/scala/iota/syntax/package.scala
@@ -3,10 +3,12 @@ package iotaz //#=scalaz
 
 package object syntax {
 
+  object evidence extends EvidenceSyntax
   object inject  extends InjectSyntax
   object injectK extends InjectKSyntax
 
   object all
-      extends InjectSyntax
+      extends EvidenceSyntax
+      with    InjectSyntax
       with    InjectKSyntax
 }

--- a/modules/examples-cats/src/main/scala/example/Evidence.scala
+++ b/modules/examples-cats/src/main/scala/example/Evidence.scala
@@ -1,0 +1,33 @@
+package example
+
+import iota.TNilK
+import iota.TListK.::
+import iota.syntax.evidence._
+
+object Evidence extends App {
+
+  class Foo[A]
+  class Bar[A]
+  class Zed[A]
+
+  // firstK will find the first available evidence for entries in a TListK
+
+  {
+    implicit val zedForString: Zed[String] = new Zed[String]
+    assert(firstK[Foo :: Bar :: Zed :: TNilK, String].value == zedForString)
+
+    {
+      implicit val barForString: Bar[String] = new Bar[String]
+      assert(firstK[Foo :: Bar :: Zed :: TNilK, String].value == barForString)
+      assert(firstK[Foo :: Zed :: Bar :: TNilK, String].value == zedForString)
+
+      {
+        implicit val fooForString: Foo[String] = new Foo[String]
+        assert(firstK[Foo :: Bar :: Zed :: TNilK, String].value == fooForString)
+        assert(firstK[Bar :: Foo :: Zed :: TNilK, String].value == barForString)
+        assert(firstK[Zed :: Bar :: Foo :: TNilK, String].value == zedForString)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This adds the ability to summon a coproduct of evidence, searching for types according to the TList parameter.

I hope to follow up by adding `AllK` evidence and eventually new higher kinded coproduct and product implementations with the respective evidence summoning support.