### PR TITLE
Fix bounds for CopK.Inject

### DIFF
--- a/modules/bench/src/codegen/scala/codegen.scala
+++ b/modules/bench/src/codegen/scala/codegen.scala
@@ -97,7 +97,7 @@ object BenchBoiler {
         ${iotaEvals.mkString("\n")}
       |
       |  private[this] implicit class InjectGenOps[F[_]](gf: Gen[F[_]]) {
-      |    def inj[G[_] <: CopK[_, _]](implicit ev: CopK.Inject[F, G]): Gen[G[_]] = gf.map(f => ev.inj(f))
+      |    def inj[G[α] <: CopK[_, α]](implicit ev: CopK.Inject[F, G]): Gen[G[_]] = gf.map(f => ev.inj(f))
       |  }
       |
         ${genAlgebras.mkString("\n")}

--- a/modules/core/src/main/scala/iota/CopK.scala
+++ b/modules/core/src/main/scala/iota/CopK.scala
@@ -28,7 +28,7 @@ object CopK {
   /** A type class witnessing the ability to inject type constructor `F`
     * into a coproduct of type constructors `G`
     */
-  sealed abstract class Inject[F[_], G[_] <: CopK[_, _]]
+  sealed abstract class Inject[F[_], G[α] <: CopK[_, α]]
       extends cats.InjectK[F, G] //#=cats
   {
     //#+scalaz
@@ -40,7 +40,7 @@ object CopK {
   }
 
   object Inject {
-    def apply[F[_], G[_] <: CopK[_, _]](implicit ev: Inject[F, G]): Inject[F, G] = ev
+    def apply[F[_], G[α] <: CopK[_, α]](implicit ev: Inject[F, G]): Inject[F, G] = ev
 
     implicit def injectFromInjectL[F[_], L <: TListK](
       implicit ev: InjectL[F, L]

--- a/modules/core/src/main/scala/iota/syntax/helpers.scala
+++ b/modules/core/src/main/scala/iota/syntax/helpers.scala
@@ -20,7 +20,7 @@ trait InjectSyntax {
 }
 
 final class InjectKOps[F[_], A](val fa: F[A]) extends AnyVal {
-  def injectK[G[_] <: CopK[_, _]](implicit ev: CopK.Inject[F, G]): G[A] =
+  def injectK[G[α] <: CopK[_, α]](implicit ev: CopK.Inject[F, G]): G[A] =
     ev.inj(fa)
 }
 

--- a/modules/examples-cats/src/main/scala/example/FreeErrorAlgebra.scala
+++ b/modules/examples-cats/src/main/scala/example/FreeErrorAlgebra.scala
@@ -28,7 +28,7 @@ class ErrorProvider[E] {
    * `ApplicativeError` instance for `Free[CP, ?]` where `CP` is a `CopK` that
    * contains the `ErrorHandling` algebra.
    */
-  implicit def applicativeErrorFreeWithErrorHandling[CP[_] <: CopK[_, _]](
+  implicit def applicativeErrorFreeWithErrorHandling[CP[α] <: CopK[_, α]](
     implicit inj: Inject[ErrorHandling, CP]
   ): ApplicativeError[Free[CP, ?], E] =
     new ApplicativeError[Free[CP, ?], E]{

--- a/modules/examples-cats/src/main/scala/example/NestedCoproducts.scala
+++ b/modules/examples-cats/src/main/scala/example/NestedCoproducts.scala
@@ -24,7 +24,7 @@ object NestedCoproducts extends App {
   type ARev[A] = CopK[Reverse[Concat[AlgA[_]#L, AlgB[_]#L]], A]
 
   implicit class InjectAny[F[_], A](val fa: F[A]) extends AnyVal {
-    def inject[G[_] <: CopK[_, _]](implicit ev: CopK.Inject[F, G]): G[A] = ev(fa)
+    def inject[G[α] <: CopK[_, α]](implicit ev: CopK.Inject[F, G]): G[A] = ev(fa)
   }
 
   // ensure that everything gets injected to the right positions

--- a/modules/tests/src/test/scala/iotatests/FreeCopKTests.scala
+++ b/modules/tests/src/test/scala/iotatests/FreeCopKTests.scala
@@ -44,9 +44,9 @@ object FreeCopK extends Properties("FreeCopK") {
   implicit lazy val evalNeg   : Neg    ~> Id = λ[Neg    ~> Id] { case Neg.Value   (v) => -v    }
   implicit lazy val evalHalf  : Half   ~> Id = λ[Half   ~> Id] { case Half.Value  (v) => v / 2 }
 
-  def liftFree[G[_] <: CopK[_, _]]: LiftFreePartial[G] = new LiftFreePartial[G]
+  def liftFree[G[α] <: CopK[_, α]]: LiftFreePartial[G] = new LiftFreePartial[G]
 
-  final class LiftFreePartial[G[_] <: CopK[_, _]] {
+  final class LiftFreePartial[G[α] <: CopK[_, α]] {
     def apply[F[_], A](fa: F[A])(
       implicit I: CopK.Inject[F, G]): Free[G, A] = Free.liftF(I.inj(fa))
   }


### PR DESCRIPTION
Properly qualify the bounds for `CopK.Inject`.