### PR TITLE
Fixes Badges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Discussion around Iota happens in the [Gitter channel](https://gitter.im/47deg/freestyle) as well as on
-[GitHub issues](https://github.com/47deg/freestyle/issues) and [pull requests](https://github.com/47deg/freestyle/pulls).
+Discussion around Iota happens in the [Gitter channel](https://gitter.im/frees-io/iota) as well as on
+[GitHub issues](https://github.com/frees-io/iota/issues) and [pull requests](https://github.com/frees-io/iota/pulls).
 
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about
 the code. Pull requests are also welcome.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2016-2017 47 Degrees. <http://47deg.com>
+   Copyright (C) 2016-2018 47 Degrees. <http://47deg.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -64,7 +64,26 @@ object ProjectPlugin extends AutoPlugin {
     ),
     orgUpdateDocFilesSetting +=
       (baseDirectory in LocalRootProject).value / "modules" / "readme" / "src" / "main" / "tut",
-    orgEnforcedFilesSetting := Nil,
+    orgEnforcedFilesSetting := List(
+      LicenseFileType(orgGithubSetting.value, orgLicenseSetting.value, startYear.value),
+      ContributingFileType(orgProjectName.value, orgGithubSetting.value),
+      VersionSbtFileType,
+      ChangelogFileType,
+      ReadmeFileType(
+        orgProjectName.value,
+        orgGithubSetting.value,
+        startYear.value,
+        orgLicenseSetting.value,
+        orgCommitBranchSetting.value,
+        sbtPlugin.value,
+        name.value,
+        version.value,
+        scalaBinaryVersion.value,
+        sbtBinaryVersion.value,
+        orgSupportedScalaJSVersion.value,
+        orgBadgeListSetting.value
+      )
+    ),
 
     orgAfterCISuccessTaskListSetting := List(
       depUpdateDependencyIssues.asRunnableItem,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers ++= Seq(Resolver.sonatypeRepo("snapshots"), Resolver.sonatypeRepo("releases"))
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.13")
+addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.19")


### PR DESCRIPTION
The problem was caused because the `orgEnforcedFilesSetting` was overridden to `Nil`.

This PR should fix it, hence the bot will keep up-to-date the README, the License, etc.