### PR TITLE
Improves CI Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,40 @@ before_install:
   fi
 
 script:
-- sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
+- sbt ++$TRAVIS_SCALA_VERSION clean compile test
 
-after_success:
-- sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
+stages:
+  - test
+  - validate
+  - deploy
+
+jobs:
+  include:
+    - stage: validate
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION orgValidateFiles
+        - sbt ++$TRAVIS_SCALA_VERSION tutReadme
+      scala: 2.12.4
+    - stage: deploy
+      script:
+        - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+            if grep -q "SNAPSHOT" version.sbt; then
+              sbt ++$TRAVIS_SCALA_VERSION publish;
+            else
+              sbt orgUpdateDocFiles;
+              git reset --hard HEAD;
+              git clean -f;
+              git checkout master;
+              git pull origin master;
+              sbt release;
+              sbt depUpdateDependencyIssues;
+            fi
+          fi
+      scala: 2.12.4
 
 cache:
   directories:
-  - $HOME/.sbt/0.13
+  - $HOME/.sbt/1.0
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/cache
   - $HOME/.sbt/launchers

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -55,13 +55,6 @@ object ProjectPlugin extends AutoPlugin {
       GitHubIssuesBadge.apply(_)
     ),
 
-    orgScriptTaskListSetting := List(
-      orgValidateFiles.asRunnableItem,
-      "clean".asRunnableItemFull,
-      "compile".asRunnableItemFull,
-      "test".asRunnableItemFull,
-      "tutReadme".asRunnableItem
-    ),
     orgUpdateDocFilesSetting +=
       (baseDirectory in LocalRootProject).value / "modules" / "readme" / "src" / "main" / "tut",
     orgEnforcedFilesSetting := List(
@@ -83,12 +76,6 @@ object ProjectPlugin extends AutoPlugin {
         orgSupportedScalaJSVersion.value,
         orgBadgeListSetting.value
       )
-    ),
-
-    orgAfterCISuccessTaskListSetting := List(
-      depUpdateDependencyIssues.asRunnableItem,
-      orgPublishReleaseTask.asRunnableItem(allModules = true, aggregated = false, crossScalaVersions = true),
-      orgUpdateDocFiles.asRunnableItem
     ),
 
     headerCreate in Compile := Nil,


### PR DESCRIPTION
This PR provides a new CI pipeline:

* Tests (for both Scala 2.11 and 2.12).
* Validate: where files and docs are validated.
* Deploy: this stage only will run if the previous stages result successfully.

![screenshot 2018-02-12 15 29 49](https://user-images.githubusercontent.com/4879373/36101420-95f95770-1009-11e8-9ee4-2db99b41fec9.png)
