### PR TITLE
Filter out some deps from the updates report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val corez = module("core", hideFolder = true, prefixSuffix = "z")
     flags    = "scalaz" :: Nil,
     yaxScala = true))
   .crossDepSettings(
-    "org.scalaz" %% "scalaz-core" % "7.2.15")
+    "org.scalaz" %% "scalaz-core" % "7.2.19")
 
 lazy val corezJVM = corez.jvm
 lazy val corezJS  = corez.js
@@ -109,7 +109,7 @@ lazy val examplesScalaz = module("examples-scalaz")
   .settings(noPublishSettings)
   .settings(macroSettings)
   .crossDepSettings(
-    "org.scalaz" %% "scalaz-effect" % "7.2.15")
+    "org.scalaz" %% "scalaz-effect" % "7.2.19")
 
 lazy val examplesScalazJVM = examplesScalaz.jvm
 lazy val examplesScalazJS  = examplesScalaz.js
@@ -134,7 +134,7 @@ lazy val docs = jvmModule("docs")
     scalacOptions in Tut := Nil,
     tutTargetDirectory := (baseDirectory in LocalRootProject).value / "docs")
   .settings(libraryDependencies +=
-    "org.scalaz" %% "scalaz-effect" % "7.2.15")
+    "org.scalaz" %% "scalaz-effect" % "7.2.19")
 
 lazy val bench = jvmModule("bench")
   .enablePlugins(JmhPlugin)
@@ -168,4 +168,4 @@ lazy val macroSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     scalaOrganization.value % "scala-compiler" % scalaVersion.value % Provided,
     scalaOrganization.value % "scala-reflect" % scalaVersion.value % Provided,
-    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)))
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)))

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -6,13 +6,11 @@ import sbtorgpolicies.OrgPoliciesKeys.orgBadgeListSetting
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.templates._
-import sbtorgpolicies.runnable.syntax._
-import dependencies.DependenciesPlugin.autoImport._
 import scoverage.ScoverageKeys._
 import org.scalajs.sbtplugin.cross.{CrossProject, CrossType}
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
-import tut.TutPlugin.autoImport._
+import com.timushev.sbt.updates.UpdatesPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
@@ -88,9 +86,11 @@ object ProjectPlugin extends AutoPlugin {
     outputStrategy := Some(StdoutOutput),
     connectInput in run := true,
     cancelable in Global := true,
-
-    crossScalaVersions :=  List("2.11.12", "2.12.4"),
-    scalaVersion       := "2.12.4"
+    crossScalaVersions := List("2.11.12", "2.12.4"),
+    scalaVersion := "2.12.4",
+    dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty") |
+      moduleFilter(organization = "org.openjdk.jmh") |
+      moduleFilter(organization = "pl.project13.scala", name = "sbt-jmh-extras")
   )
 
 }


### PR DESCRIPTION
With these changes, only scalajs is shown in the dependency updates report:
```bash
sbt:iota> dependencyUpdates
[info] No dependency updates found for iotaz-core
[info] No dependency updates found for iota
[info] No dependency updates found for iota-examples-scalaz
[info] No dependency updates found for iota-core
[info] Found 3 dependency updates for iota-core
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] Found 3 dependency updates for iotaz-core
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] Found 3 dependency updates for iotaz-scalacheck
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] Found 3 dependency updates for iota-scalacheck
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] No dependency updates found for iotaz-scalacheck
[info] Found 3 dependency updates for iota-examples-scalaz
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] No dependency updates found for iota-examples-cats
[info] No dependency updates found for iota-scalacheck
[info] Found 3 dependency updates for iota-examples-cats
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] No dependency updates found for iota-readme
[info] No dependency updates found for iota-docs
[info] No dependency updates found for iota-bench
[info] No dependency updates found for iota-tests
[info] No dependency updates found for iotaz-tests
[info] Found 3 dependency updates for iota-tests
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
[info] Found 3 dependency updates for iotaz-tests
[info]   org.scala-js:scalajs-compiler:plugin->default(compile) : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-library                           : 0.6.20 -> 0.6.22
[info]   org.scala-js:scalajs-test-interface:test               : 0.6.20 -> 0.6.22
```