### PR TITLE
Add full path for scala.Int type to macros

### DIFF
--- a/modules/core/src/main/scala/iota/internal/TypeListMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/TypeListMacros.scala
@@ -25,7 +25,7 @@ final class TypeListMacros(val c: Context) {
       index    <- Right(algebras.indexWhere(_ =:= A))
                     .filterOrElse(_ >= 0, s"$A is not a member of $L")
     } yield
-      q"new ${tb.iotaPackage}.TList.Pos[$L, $A]{ override val index: Int = $index }", true)
+      q"new ${tb.iotaPackage}.TList.Pos[$L, $A]{ override val index: scala.Int = $index }", true)
   }
 
   def materializeTListKPos[L <: TListK, F[_]](
@@ -42,7 +42,7 @@ final class TypeListMacros(val c: Context) {
       index    <- Right(algebras.indexWhere(_ =:= F))
                     .filterOrElse(_ >= 0, s"$F is not a member of $L")
     } yield
-      q"new ${tb.iotaPackage}.TListK.Pos[$L, $F]{ override val index: Int = $index }", true)
+      q"new ${tb.iotaPackage}.TListK.Pos[$L, $F]{ override val index: scala.Int = $index }", true)
   }
 
   def materializeTListHPos[L <: TListH, F[_[_]]](
@@ -59,7 +59,7 @@ final class TypeListMacros(val c: Context) {
       index    <- Right(algebras.indexWhere(_ =:= F))
                     .filterOrElse(_ >= 0, s"$F is not a member of $L")
     } yield
-        q"new ${tb.iotaPackage}.TListH.Pos[$L, $F]{ override val index: Int = $index }", true)
+        q"new ${tb.iotaPackage}.TListH.Pos[$L, $F]{ override val index: scala.Int = $index }", true)
   }
 
   def materializeTListLength[L <: TList](


### PR DESCRIPTION
If some project is compiled with `-Yno-imports`, there is no `Int` in scope. This leads to a silent error and implicit not found, requires importing scala.Int explicitly to actually get things to work.
In this PR I added fully qualified type replacing `Int` in macros to `scala.Int` which solves the problem.

I am not sure if or how this change should be tested. I didn't manage to unimport Int. Maybe `-Yno-imports` should be added for tests project?