### PR TITLE
Add fully quialified names to avoid problems with -Xno-import

### DIFF
--- a/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
@@ -95,7 +95,7 @@ final class CopKFunctionKMacros(val c: Context) {
 
     val handlers = arrs.zipWithIndex.map { case (arr, i) =>
       val name = TermName(s"arr$i")
-      val pre = q"private[this] val $name = $arr.asInstanceOf[$NatTransType[Any, $G]]"
+      val pre = q"private[this] val $name = $arr.asInstanceOf[$NatTransType[_root_.scala.Any, $G]]"
       val handler = (fa: TermName) => q"$name($fa.value)"
       (pre, handler)
     }

--- a/modules/core/src/main/scala/iota/internal/TypeListMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/TypeListMacros.scala
@@ -25,7 +25,7 @@ final class TypeListMacros(val c: Context) {
       index    <- Right(algebras.indexWhere(_ =:= A))
                     .filterOrElse(_ >= 0, s"$A is not a member of $L")
     } yield
-      q"new ${tb.iotaPackage}.TList.Pos[$L, $A]{ override val index: scala.Int = $index }", true)
+      q"new ${tb.iotaPackage}.TList.Pos[$L, $A]{ override val index: _root_.scala.Int = $index }", true)
   }
 
   def materializeTListKPos[L <: TListK, F[_]](
@@ -42,7 +42,7 @@ final class TypeListMacros(val c: Context) {
       index    <- Right(algebras.indexWhere(_ =:= F))
                     .filterOrElse(_ >= 0, s"$F is not a member of $L")
     } yield
-      q"new ${tb.iotaPackage}.TListK.Pos[$L, $F]{ override val index: scala.Int = $index }", true)
+      q"new ${tb.iotaPackage}.TListK.Pos[$L, $F]{ override val index: _root_.scala.Int = $index }", true)
   }
 
   def materializeTListHPos[L <: TListH, F[_[_]]](
@@ -59,7 +59,7 @@ final class TypeListMacros(val c: Context) {
       index    <- Right(algebras.indexWhere(_ =:= F))
                     .filterOrElse(_ >= 0, s"$F is not a member of $L")
     } yield
-        q"new ${tb.iotaPackage}.TListH.Pos[$L, $F]{ override val index: scala.Int = $index }", true)
+        q"new ${tb.iotaPackage}.TListH.Pos[$L, $F]{ override val index: _root_.scala.Int = $index }", true)
   }
 
   def materializeTListLength[L <: TList](

--- a/modules/core/src/main/scala/iota/internal/toolbelts.scala
+++ b/modules/core/src/main/scala/iota/internal/toolbelts.scala
@@ -396,9 +396,9 @@ private[internal] sealed trait CoproductMacroAPIs { self: MacroToolbelt =>
         (${toIndex(fa)}: @_root_.scala.annotation.switch) match {
           case ..$cases
           case i => throw new _root_.java.lang.Exception(
-            s"iota internal error: index " + i + " out of bounds for " + this)
+            "iota internal error: index " + i + " out of bounds for " + this)
         }
-      override def toString: String = $toStringValue
+      override def toString: _root_.scala.Predef.String = $toStringValue
     }
     """
   }


### PR DESCRIPTION
Hi,

Here is another PR to account for problems with projects using `-Xno-import`.

I added fully qualified names for `Any` and `String`. I also added ` _root_` prefix to previously introduced `scala.Int` for consistency. Lastly I removed string interpolation that was not used and demands StringContext symbol in scope.