### PR TITLE
Fixed bug in NT macro

### DIFF
--- a/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
@@ -51,7 +51,9 @@ final class CopKFunctionKMacros(val c: Context) {
       lookup = unorderedPairs.toMap
 
       arrs <- Traverse[List].traverse(tpes)(tpe =>
-        lookup.get(tpe).toRight(s"Missing interpreter $NatTransName[$tpe, $G]").toAvowalNel).toEither
+        lookup.get(tpe).orElse {
+          lookup.keySet.find(_ =:= tpe).map(lookup.apply)
+        }.toRight(s"Missing interpreter $NatTransName[$tpe, $G]").toAvowalNel).toEither
     } yield makeInterpreter(F, copK.L, G, arrs))
   }
 

--- a/modules/tests/src/test/scala/iotatests/CopKFunctionKGeneric.scala
+++ b/modules/tests/src/test/scala/iotatests/CopKFunctionKGeneric.scala
@@ -1,0 +1,25 @@
+package iotatests
+
+import cats._   //#=cats
+import scalaz._ //#=scalaz
+
+import iota._  //#=cats
+import iotaz._ //#=scalaz
+
+object CopKFunctionKGenericTests {
+
+  import TListK.:::
+
+  class X
+  class Y
+
+  class T[A]
+  class M[F, A]
+
+  type Generic[A] = CopK[M[X, ?] ::: M[Y, ?] ::: TNilK, A]
+
+  val mx: M[X, ?] ~> T = null
+  val my: M[Y, ?] ~> T = null
+  CopKNT.of[Generic, T](mx, my)
+
+}


### PR DESCRIPTION
I came across this bug. I don't understand it deeply, but it is there. 
For the test code I provided `lookup.keySet` and `tpes` are different. The types differ in their `?` part. I solved it by a fallback that uses proper equality.
Please let me know if I can improve something in this PR.