### PR TITLE
Implement hashcode for all data types

### DIFF
--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -13,6 +13,10 @@ final class Cop[LL <: TList] private(
     case _              => false
   }
 
+  override def hashCode(): Int = {
+    41 * index + value.##
+  }
+
   override def toString: String =
     s"Cop($value @ $index)"
 }

--- a/modules/core/src/main/scala/iota/CopH.scala
+++ b/modules/core/src/main/scala/iota/CopH.scala
@@ -15,6 +15,10 @@ final class CopH[LL <: TListH, F[_]] private(
     case _                  => false
   }
 
+  override def hashCode(): Int = {
+    41 * index + value.##
+  }
+
   override def toString: String =
     s"CopH($value @ $index)"
 }

--- a/modules/core/src/main/scala/iota/CopK.scala
+++ b/modules/core/src/main/scala/iota/CopK.scala
@@ -16,6 +16,10 @@ final class CopK[LL <: TListK, A] private(
     case _                  => false
   }
 
+  override def hashCode(): Int = {
+    41 * index + value.##
+  }
+
   override def toString: String =
     s"CopK($value @ $index)"
 }

--- a/modules/core/src/main/scala/iota/Prod.scala
+++ b/modules/core/src/main/scala/iota/Prod.scala
@@ -14,6 +14,10 @@ final class Prod[LL <: TList] private(
     case _               => false
   }
 
+  override def hashCode(): Int = {
+    values.hashCode()
+  }
+
   override def toString: String =
     s"""Prod(${values.mkString(", ")})"""
 }

--- a/modules/tests/src/test/scala/iotatests/HashcodeTests
+++ b/modules/tests/src/test/scala/iotatests/HashcodeTests
@@ -1,0 +1,26 @@
+package iotatests
+
+import iota._  //#=cats
+import iotaz._ //#=scalaz
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop._
+import org.scalacheck.ScalacheckShapeless._
+
+object HashcodeTests extends Properties("HashcodeTests") {
+
+  property("keep equals - hashcode contract for CopK") = {
+    import TListK.::
+    type CC[A] = CopK[List :: TNilK, A]
+    val I = CopK.Inject[List, CC]
+    forAll(arbitrary[Map[List[Int], String]].suchThat(_.size > 0)) { map =>
+      val copMap = map.map { case (k, v) => (I(k), v) }
+      val key = copMap.keys.head
+      val keyCopy = I(I.prj(key).get)
+
+      copMap.get(keyCopy) ?= copMap.get(key)
+    }
+  }
+
+}


### PR DESCRIPTION
Hashcode implementation is missing for `CopK` and other classes. This means that they use reference equality in maps. If I inject the same value to a coproduct twice, hashcode will not be equals causing problems when using maps.

Sorry for rather poor tests but I don't have time now to prepare something pretty.