### PR TITLE
use openjdk8 instead of oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 scala:
 - 2.11.12


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.